### PR TITLE
Add deprecation for context shifting `{{#each`.

### DIFF
--- a/ext/plugins/base.js
+++ b/ext/plugins/base.js
@@ -83,7 +83,7 @@ module.exports = function(options) {
   };
 
   BasePlugin.prototype.isDisabled = function() {
-    return this.config === false;
+    return !this.config;
   };
 
   BasePlugin.prototype.log = function(result) {

--- a/ext/plugins/deprecations/lint-deprecated-each-syntax.js
+++ b/ext/plugins/deprecations/lint-deprecated-each-syntax.js
@@ -11,18 +11,47 @@ module.exports = function(addonContext) {
 
   DeprecatedEachSyntax.prototype.detect = function(node) {
     return astInfo.isBlockStatement(node) &&
-      node.path.original === 'each' &&
-      node.params.length > 1 &&
-      node.params[1].original === 'in';
+      node.path.original === 'each';
   };
 
   DeprecatedEachSyntax.prototype.process = function(node) {
+    var isEachIn = node.params.length > 1 && node.params[1].original === 'in';
+    var isEachContextShifting = node.params.length === 1 && node.program.blockParams.length === 0;
+
+    if (isEachIn) {
+      this.processEachIn(node);
+    } else if (isEachContextShifting) {
+      this.processEachContextShifting(node);
+    }
+  };
+
+  DeprecatedEachSyntax.prototype.processEachIn = function(node) {
     var params = node.params;
     var singular = params[0].original;
     var collection = params[2].original;
 
     var actual = '{{#each ' + singular + ' in ' + collection + '}}';
     var expected = '{{#each ' + collection + ' as |' + singular + '|}}';
+
+    var message = 'Deprecated {{#each}} usage. See the deprecation guide at ' + DEPRECATION_URL;
+
+    this.log({
+      message: message,
+      line: node.loc && node.loc.start.line,
+      column: node.loc && node.loc.start.column,
+      source: actual,
+      fix: {
+        text: expected
+      }
+    });
+  };
+
+  DeprecatedEachSyntax.prototype.processEachContextShifting = function(node) {
+    var params = node.params;
+    var collection = params[0].original;
+
+    var actual = '{{#each ' + collection + '}}';
+    var expected = '{{#each ' + collection + ' as |item|}}';
 
     var message = 'Deprecated {{#each}} usage. See the deprecation guide at ' + DEPRECATION_URL;
 

--- a/ext/plugins/deprecations/lint-deprecated-each-syntax.js
+++ b/ext/plugins/deprecations/lint-deprecated-each-syntax.js
@@ -24,21 +24,21 @@ module.exports = function(addonContext) {
     var actual = '{{#each ' + singular + ' in ' + collection + '}}';
     var expected = '{{#each ' + collection + ' as |' + singular + '|}}';
 
-    var message = [
-      'Deprecated {{#each}} usage ',
-      'Actual: ' + actual,
-      'Expected (rewrite the template to this): ' + expected,
-      'The `#each in` syntax was deprecated in 1.11 and removed in Ember 2.0.',
-      'See the deprecation guide at ' + DEPRECATION_URL
-    ].join('\n');
+    var message = 'Deprecated {{#each}} usage. See the deprecation guide at ' + DEPRECATION_URL;
 
     this.log({
       message: message,
       line: node.loc && node.loc.start.line,
       column: node.loc && node.loc.start.column,
-      source: this.sourceForNode(node)
+      source: actual,
+      fix: {
+        text: expected
+      }
     });
   };
 
   return DeprecatedEachSyntax;
 };
+
+
+module.exports.DEPRECATION_URL = DEPRECATION_URL;

--- a/test/unit/plugins/deprecations/lint-deprecated-each-syntax-test.js
+++ b/test/unit/plugins/deprecations/lint-deprecated-each-syntax-test.js
@@ -8,6 +8,8 @@ var message = 'Deprecated {{#each}} usage. See the deprecation guide at ' + DEPR
 generateRuleTests({
   name: 'deprecated-each-syntax',
 
+  config: true,
+
   good: [
     {
       template: '{{#each posts as |post|}}{{post.name}}{{/each}}'
@@ -27,6 +29,21 @@ generateRuleTests({
         column: 0,
         fix: {
           text: '{{#each posts as |post|}}'
+        }
+      }
+    },
+    {
+      template: '{{#each posts}}{{name}}{{/each}}',
+
+      result: {
+        rule: 'deprecated-each-syntax',
+        message: message,
+        moduleId: 'layout.hbs',
+        source: '{{#each posts}}',
+        line: 1,
+        column: 0,
+        fix: {
+          text: '{{#each posts as |item|}}'
         }
       }
     }

--- a/test/unit/plugins/deprecations/lint-deprecated-each-syntax-test.js
+++ b/test/unit/plugins/deprecations/lint-deprecated-each-syntax-test.js
@@ -1,6 +1,9 @@
 'use strict';
 
 var generateRuleTests = require('../../../helpers/rule-test-harness');
+var DEPRECATION_URL = require('../../../../ext/plugins/deprecations/lint-deprecated-each-syntax').DEPRECATION_URL;
+
+var message = 'Deprecated {{#each}} usage. See the deprecation guide at ' + DEPRECATION_URL;
 
 generateRuleTests({
   name: 'deprecated-each-syntax',
@@ -17,11 +20,14 @@ generateRuleTests({
 
       result: {
         rule: 'deprecated-each-syntax',
-        message: 'Deprecated {{#each}} usage \nActual: {{#each post in posts}}\nExpected (rewrite the template to this): {{#each posts as |post|}}\nThe `#each in` syntax was deprecated in 1.11 and removed in Ember 2.0.\nSee the deprecation guide at http://emberjs.com/deprecations/v1.x/#toc_code-in-code-syntax-for-code-each-code',
+        message: message,
         moduleId: 'layout.hbs',
-        source: '{{#each post in posts}}{{post.name}}{{/each}}',
+        source: '{{#each post in posts}}',
         line: 1,
-        column: 0
+        column: 0,
+        fix: {
+          text: '{{#each posts as |post|}}'
+        }
       }
     }
   ]


### PR DESCRIPTION
/cc @fivetanley