### PR TITLE
Prevent errors when calling `.verify`.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,13 +44,21 @@ Linter.prototype = {
   verify: function(options) {
     var messages = [];
 
-    compile(options.source, {
-      moduleName: options.moduleId,
-      rawSource: options.source,
-      plugins: {
-        ast: this.buildASTPlugins(messages)
-      }
-    });
+    try {
+      compile(options.source, {
+        moduleName: options.moduleId,
+        rawSource: options.source,
+        plugins: {
+          ast: this.buildASTPlugins(messages)
+        }
+      });
+    } catch (error) {
+      messages.push({
+        fatal: true,
+        message: error.message,
+        source: error.stack
+      });
+    }
 
     return messages;
   },

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -126,5 +126,14 @@ describe('public api', function() {
 
       assert.deepEqual(result, expected);
     });
+
+    it('returns a "fatal" result object if an error occurs during parsing', function() {
+      var template = '<div>';
+      var result = linter.verify({
+        source: template
+      });
+
+      assert(result[0].fatal === true);
+    });
   });
 });


### PR DESCRIPTION
This change adds a small amount of error handling to the linter, so that calling `linter.verify` on broken templates still returns an array of objects. In this case the result object would include the following properties:

* `fatal` -- `true`
* `message` -- The `error.message` for the thrown error.
* `source` -- The `error.stack` for the thrown error.