### PR TITLE
Add ability to have `pending` files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ It is also possible to disable specific rules (or all rules) in a template itsel
 
 It is not currently possible to change rule configuration in the template.
 
+### Configuration Keys
+
+The following properties are allowed in the root of the `.template-lintrc.js` configuration file:
+
+* `rules` -- This is an object containing rule specific configuration (see details for each rule below).
+* `extends` -- This is a string that allows you to specify an internally curated list of rules (we suggest `recommended` here).
+* `pending` -- An array of module id's that are still pending. The goal of this array is to allow incorporating template linting
+  into an existing project, without changing every single template file. You can add all existing templates to this `pending` listing
+  and slowly work through them, while at the same time ensuring that new templates added to the project pass all defined rules.
+
 ## Rules
 
 #### bare-strings
@@ -91,7 +101,6 @@ When the config value of `true` is used the following configuration is used:
  * `whitelist` - `(),.&+-=*/#%!?:[]{}`
  * `globalAttributes` - `title`
  * `elementAttributes` - `{ img: ['alt'], input: ['placeholder'] }`
-
 
 #### block-indentation
 

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -9,5 +9,7 @@ module.exports = {
     'lint-self-closing-void-elements': true,
     'triple-curlies': true,
     'deprecated-each-syntax': true
-  }
+  },
+
+  pending: []
 };

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -5,7 +5,7 @@ var assign = require('lodash').assign;
 var existsSync = require('exists-sync');
 var chalk = require('chalk');
 
-var KNOWN_ROOT_PROPERTIES = ['extends', 'rules'];
+var KNOWN_ROOT_PROPERTIES = ['extends', 'rules', 'pending'];
 
 function readConfigFromDisk(options) {
   var providedConfigPath = options.configPath;
@@ -20,6 +20,7 @@ function readConfigFromDisk(options) {
 
 function ensureRootProperties(config) {
   config.rules = config.rules || {};
+  config.pending = config.pending || [];
 }
 
 function migrateRulesFromRoot(config, options) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,8 @@ Linter.prototype = {
       messages.push({
         fatal: true,
         message: error.message,
-        source: error.stack
+        source: error.stack,
+        severity: 2
       });
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,14 +15,13 @@ Linter.prototype = {
   constructor: Linter,
 
   loadConfig: function() {
-    if (this.options.config) {
-      this.config = this.options.config;
-    } else {
-      this.config = getConfig(this.options);
-    }
+    this.config = getConfig(this.options);
   },
 
-  buildASTPlugins: function(results) {
+  buildASTPlugins: function(config) {
+    var results = config.results;
+    var defaultSeverity = config.pending ? 1 : 2;
+
     function addToResults(result) {
       results.push(result);
     }
@@ -32,7 +31,8 @@ Linter.prototype = {
       var plugin = plugins[pluginName]({
         name: pluginName,
         config: this.config.rules[pluginName],
-        log: addToResults
+        log: addToResults,
+        defaultSeverity: defaultSeverity
       });
 
       astPlugins.push(plugin);
@@ -41,22 +41,41 @@ Linter.prototype = {
     return astPlugins;
   },
 
+  isPending: function(moduleId) {
+    return this.config.pending.indexOf(moduleId) > -1;
+  },
+
   verify: function(options) {
     var messages = [];
+    var moduleIsPending = this.isPending(options.moduleId);
+
+    var pluginConfig = {
+      results: messages,
+      pending: moduleIsPending
+    };
 
     try {
       compile(options.source, {
         moduleName: options.moduleId,
         rawSource: options.source,
         plugins: {
-          ast: this.buildASTPlugins(messages)
+          ast: this.buildASTPlugins(pluginConfig)
         }
       });
     } catch (error) {
       messages.push({
         fatal: true,
+        moduleId: options.moduleId,
         message: error.message,
         source: error.stack,
+        severity: 2
+      });
+    }
+
+    if (moduleIsPending && messages.length === 0) {
+      messages.push({
+        message: 'Pending module (`' + options.moduleId + '`) passes all rules. Please remove `' + options.moduleId + '` from pending list.',
+        moduleId: options.moduleId,
         severity: 2
       });
     }

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var assign = require('lodash').assign;
+
 module.exports = function(options) {
   var log = options.log;
   var config = options.config;
@@ -87,10 +89,14 @@ module.exports = function(options) {
   };
 
   BasePlugin.prototype.log = function(result) {
-    result.moduleId = this.options.moduleName;
-    result.rule = this.ruleName;
+    var defaults = {
+      moduleId: this.options.moduleName,
+      rule: this.ruleName,
+      severity: 2
+    };
+    var reportedResult = assign({}, defaults, result);
 
-    this._log(result);
+    this._log(reportedResult);
   };
 
   BasePlugin.prototype.detect = function() {

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -6,6 +6,7 @@ module.exports = function(options) {
   var log = options.log;
   var config = options.config;
   var ruleName = options.name;
+  var defaultSeverity = options.defaultSeverity;
 
   function BasePlugin(options) {
     this.options = options;
@@ -15,6 +16,7 @@ module.exports = function(options) {
     this.source = this.options.rawSource.split(/(?:\r\n?|\n)/g);
 
     this.ruleName = ruleName;
+    this.severity = defaultSeverity;
     this.config = this.parseConfig(config);
     this._log = log;
   }
@@ -92,7 +94,7 @@ module.exports = function(options) {
     var defaults = {
       moduleId: this.options.moduleName,
       rule: this.ruleName,
-      severity: 2
+      severity: this.severity
     };
     var reportedResult = assign({}, defaults, result);
 

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -108,14 +108,16 @@ describe('public api', function() {
           line: 1,
           column: 4,
           source: 'Here too!!',
-          rule: 'bare-strings'
+          rule: 'bare-strings',
+          severity: 2
         }, {
           message: 'Non-translated string used',
           moduleId: templatePath,
           line: 2,
           column: 5,
           source: 'Bare strings are bad...',
-          rule: 'bare-strings'
+          rule: 'bare-strings',
+          severity: 2
         }
       ];
 

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -137,5 +137,73 @@ describe('public api', function() {
 
       assert(result[0].fatal === true);
     });
+
+    it('defaults all messages to warning severity level when module listed in pending', function() {
+      linter = new Linter({
+        console: mockConsole,
+        config: {
+          rules: { 'bare-strings': true },
+          pending: ['some/path/here']
+        }
+      });
+
+      var template = '<div>bare string</div>';
+      var result = linter.verify({
+        source: template,
+        moduleId: 'some/path/here'
+      });
+
+      var expected = {
+        message: 'Non-translated string used',
+        moduleId: 'some/path/here',
+        line: 1,
+        column: 5,
+        source: 'bare string',
+        rule: 'bare-strings',
+        severity: 1
+      };
+
+      assert.deepEqual(result, [expected]);
+    });
+
+    it('module listed in pending passes an error results', function() {
+      linter = new Linter({
+        console: mockConsole,
+        config: {
+          rules: { 'bare-strings': true },
+          pending: ['some/path/here']
+        }
+      });
+
+      var template = '<div></div>';
+      var result = linter.verify({
+        source: template,
+        moduleId: 'some/path/here'
+      });
+
+      var expected = {
+        message: 'Pending module (`some/path/here`) passes all rules. Please remove `some/path/here` from pending list.',
+        moduleId: 'some/path/here',
+        severity: 2
+      };
+
+      assert.deepEqual(result, [expected]);
+    });
+  });
+
+  describe('Linter.prototype.isPending', function() {
+    it('returns true when the provided moduleId is listed in `pending`', function() {
+      var linter = new Linter({
+        console: mockConsole,
+        config: {
+          pending: [
+            'some/path/here'
+          ]
+        }
+      });
+
+      assert(linter.isPending('some/path/here'));
+      assert(!linter.isPending('some/other/path'));
+    });
   });
 });

--- a/test/helpers/rule-test-harness.js
+++ b/test/helpers/rule-test-harness.js
@@ -3,6 +3,7 @@
 var assert = require('power-assert');
 var assertDiff = require('assert-diff');
 var Linter = require('../../lib/index');
+var assign = require('lodash').assign;
 
 module.exports = function(options) {
 
@@ -36,9 +37,20 @@ module.exports = function(options) {
         testMethod = it;
       }
 
+      function parseResult(result) {
+        var defaults = {
+          rule: options.name,
+          moduleId: 'layout.hbs',
+          severity: 2
+        };
+
+        return assign({}, defaults, result);
+      }
 
       testMethod('logs a message in the console when given `' + badItem.template + '`', function() {
         var expectedResults = badItem.results || [badItem.result];
+
+        expectedResults = expectedResults.map(parseResult);
 
         if (badItem.config) {
           config = badItem.config;

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -72,7 +72,7 @@ describe('get-config', function() {
   });
 
   it('migrates rules in the config root into `rules` property', function() {
-    var expected = { rules: { 'bare-strings': true }};
+    var expected = { pending: [], rules: { 'bare-strings': true }};
     var actual = getConfig({
       console: { log: function() { }},
       config: {


### PR DESCRIPTION
This will enable users to drop ember-cli-template-lint / ember-template-lint into a project and ensure new files (that are not on the pending list) pass rules but not require updating all the files at once just to get the tests passing.