### PR TITLE
Fix wrong rule name in recommended.js

### DIFF
--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -6,7 +6,7 @@ module.exports = {
     'block-indentation': 2,
     'html-comments': true,
     'nested-interactive': true,
-    'lint-self-closing-void-elements': true,
+    'self-closing-void-elements': true,
     'triple-curlies': true,
     'deprecated-each-syntax': true
   },


### PR DESCRIPTION
lint-self-closing-void-elements is actually called self-closing-void-elements