### PR TITLE
Remove `bare-strings` from recommended configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,17 @@ You can turn on specific rules by toggling them in a
 
 ```javascript
 module.exports = {
-  extends: 'recommended'
+  extends: 'recommended',
+
+  rules: {
+    'bare-strings': true
+  }
 }
 ```
 
-This extends from the builtin recommended configuration ([lib/config/recommended.js](https://github.com/rwjblue/ember-template-lint/blob/master/lib/config/recommended.js)).
+This extends from the builtin recommended configuration ([lib/config/recommended.js](https://github.com/rwjblue/ember-template-lint/blob/master/lib/config/recommended.js)),
+and also enables the `bare-strings` rule (see [here](https://github.com/rwjblue/ember-template-lint#bare-strings)).
+
 Using this mechanism allows you to extend from the builtin, and modify specific rules as needed.
 
 Some rules also allow setting additional configuration, for example if you would like to configure

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -2,7 +2,6 @@
 
 module.exports = {
   rules: {
-    'bare-strings': true,
     'block-indentation': 2,
     'html-comments': true,
     'nested-interactive': true,


### PR DESCRIPTION
I believe that the majority of Ember applications should deal with localization properly, and this was why I originally configured `bare-strings` as a default. However, @mmun suggested that this is very much a concern that should be controlled outside of ember-template-lint (likely via the presence of an addon like `ember-i18n` or `ember-intl`).

I agree with @mmun, and would like to work with ember-intl/ember-i18n to get this to "just work" when those addons are present, but in the default case we should not include the `bare-strings` rule.