### PR TITLE
rule Quotes (WIP)

### DIFF
--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -7,5 +7,6 @@ module.exports = {
   'triple-curlies': require('./lint-triple-curlies'),
   'self-closing-void-elements': require('./lint-self-closing-void-elements'),
   'nested-interactive': require('./lint-nested-interactive'),
+  'quotes': require('./lint-quotes'),
   'deprecated-each-syntax': require('./deprecations/lint-deprecated-each-syntax')
 };

--- a/lib/rules/lint-quotes.js
+++ b/lib/rules/lint-quotes.js
@@ -13,7 +13,7 @@
 
  The following values are valid configuration:
 
-   * boolean -- `false` for disabled. `true` to enforce any qoutes
+   * boolean -- `false` for disabled. `true` to enforce any quotes
    * string -- `single` of `double` for enforce style
  */
 
@@ -60,51 +60,8 @@ module.exports = function(addonContext) {
     );
   };
 
-  LogQuotes.prototype._processAttributeTextNode = function(attribute) {
-    if (attribute.value.chars.length === 0) {
-      return;
-    }
-
-    var source = this.sourceForNode(attribute);
-    var qouteCharacter = source[source.length - 1];
-
-    if (!this.config.shouldTestQuoteType) {
-      if (qouteCharacter === '"' || qouteCharacter === '\'') {
-        return;
-      } else {
-        this.log({
-          message: 'Quotes: you should use quotes for attributes',
-          line: attribute.loc.start.line,
-          column: attribute.loc.start.column,
-          source: source
-        });
-        return;
-      }
-    }
-
-    if (this.config.quoteCharacter === qouteCharacter) {
-      return;
-    }
-
-    var undesiredQouteStyle = (
-      this.config.quotesType === SINGLE_QUOTES_NAME ?
-        DOUBLE_QUOTES_NAME :
-        SINGLE_QUOTES_NAME
-    );
-
-    this.log({
-      message: 'Quotes: you got ' + undesiredQouteStyle +
-        ' quotes when you set quotes style to ' + this.config.quotesType +
-        ' quotes',
-      line: attribute.loc.start.line,
-      column: attribute.loc.start.column,
-      source: source
-    });
-    return;
-  };
-
-  LogQuotes.prototype._processNode = function(node) {
-    var source = this.sourceForNode(node);
+  LogQuotes.prototype._processNode = function(node, source) {
+    source = _.isString(source) ? source : this.sourceForNode(node);
     var qouteCharacter = source[source.length - 1];
 
     if (!this.config.shouldTestQuoteType) {
@@ -161,12 +118,16 @@ module.exports = function(addonContext) {
   LogQuotes.prototype._processAttribute = function(attribute) {
     switch(attribute.value.type) {
     case 'TextNode':
-      return this._processAttributeTextNode(attribute);
+      if (attribute.value.chars.length > 0) {
+        this._processNode(attribute, this.sourceForNode(attribute));
+      }
+      break;
     case 'MustacheStatement':
-      return this._processAttributeMustacheStatement(attribute.value);
-    // case 'ConcatStatement':
-    default:
-      return null;
+      this._processAttributeMustacheStatement(attribute.value);
+      break;
+    case 'ConcatStatement':
+      /** @todo */
+      break;
     }
   };
 

--- a/lib/rules/lint-quotes.js
+++ b/lib/rules/lint-quotes.js
@@ -53,7 +53,7 @@ module.exports = function(addonContext) {
     throw new Error(errorMessage);
   };
 
-  LogQuotes.prototype._processStringLiteralNode = function(node, source) {
+  LogQuotes.prototype._processStringLiteral = function(node, source) {
     source = _.isString(source) ? source : this.sourceForNode(node);
     var qouteCharacter = source[source.length - 1];
 
@@ -92,7 +92,7 @@ module.exports = function(addonContext) {
 
   LogQuotes.prototype._processTextNode = function(node) {
     if (node.value.chars.length > 0) {
-      this._processStringLiteralNode(node, this.sourceForNode(node));
+      this._processStringLiteral(node, this.sourceForNode(node));
     }
   };
 
@@ -100,7 +100,7 @@ module.exports = function(addonContext) {
     var processNode = _.bind(function(node) {
       switch(node.type) {
       case 'StringLiteral':
-        this._processStringLiteralNode(node);
+        this._processStringLiteral(node);
         break;
       case 'SubExpression':
         this._processMustacheStatement(node);
@@ -116,7 +116,7 @@ module.exports = function(addonContext) {
 
   LogQuotes.prototype._processConcatStatement = function(node) {
     // NOTE: check if there is no more reasonable solution
-    this._processStringLiteralNode(node, this.sourceForNode(node));
+    this._processStringLiteral(node, this.sourceForNode(node));
   };
 
   LogQuotes.prototype._processAttribute = function(node) {
@@ -134,12 +134,12 @@ module.exports = function(addonContext) {
     var pluginContext = this;
 
     return {
-      MustacheStatement: function(node) {
-        pluginContext._processMustacheStatement(node);
-      },
-
       AttrNode: function(node) {
         pluginContext._processAttribute(node);
+      },
+
+      StringLiteral: function(node) {
+        pluginContext._processStringLiteral(node);
       }
     };
   };

--- a/lib/rules/lint-quotes.js
+++ b/lib/rules/lint-quotes.js
@@ -97,14 +97,20 @@ module.exports = function(addonContext) {
     });
   };
 
-  LogQuotes.prototype._processAttributeMustacheStatement = function(node) {
+  LogQuotes.prototype._processTextNode = function(node) {
+    if (node.value.chars.length > 0) {
+      this._processNode(node, this.sourceForNode(node));
+    }
+  };
+
+  LogQuotes.prototype._processMustacheStatement = function(node) {
     var processNode = _.bind(function(node) {
       switch(node.type) {
       case 'StringLiteral':
         this._processNode(node);
         break;
       case 'SubExpression':
-        this._processAttributeMustacheStatement(node);
+        this._processMustacheStatement(node);
         break;
       }
     }, this);
@@ -115,15 +121,13 @@ module.exports = function(addonContext) {
       .forEach(processNode);
   };
 
-  LogQuotes.prototype._processAttribute = function(attribute) {
-    switch(attribute.value.type) {
+  LogQuotes.prototype._processAttribute = function(node) {
+    switch(node.value.type) {
     case 'TextNode':
-      if (attribute.value.chars.length > 0) {
-        this._processNode(attribute, this.sourceForNode(attribute));
-      }
+      this._processTextNode(node);
       break;
     case 'MustacheStatement':
-      this._processAttributeMustacheStatement(attribute.value);
+      this._processMustacheStatement(node.value);
       break;
     case 'ConcatStatement':
       /** @todo */

--- a/lib/rules/lint-quotes.js
+++ b/lib/rules/lint-quotes.js
@@ -73,7 +73,7 @@ module.exports = function(addonContext) {
         return;
       } else {
         this.log({
-          message: 'Quotes: you should use qoutes for HTML attributes',
+          message: 'Quotes: you should use quotes for attributes',
           line: attribute.loc.start.line,
           column: attribute.loc.start.column,
           source: source
@@ -94,8 +94,8 @@ module.exports = function(addonContext) {
 
     this.log({
       message: 'Quotes: you got ' + undesiredQouteStyle +
-        ' qoutes for an attribute instead of ' + this.config.quotesType +
-        ' qoutes',
+        ' quotes when you set quotes style to ' + this.config.quotesType +
+        ' quotes',
       line: attribute.loc.start.line,
       column: attribute.loc.start.column,
       source: source
@@ -154,7 +154,7 @@ module.exports = function(addonContext) {
 
     _([])
       .concat(node.params)
-      .concat(_.map(node.hash.pairs, 'value'))
+      .concat(_.map(node.hash.pairs, _.property('value')))
       .forEach(processNode);
   };
 

--- a/lib/rules/lint-quotes.js
+++ b/lib/rules/lint-quotes.js
@@ -55,8 +55,8 @@ module.exports = function(addonContext) {
 
   LogQuotes.prototype.detect = function(node) {
     return (
-      node.type === 'ElementNode' &&
-      node.attributes.length > 0
+      (node.type === 'MustacheStatement') ||
+      (node.type === 'ElementNode' && node.attributes.length > 0)
     );
   };
 
@@ -143,7 +143,14 @@ module.exports = function(addonContext) {
   };
 
   LogQuotes.prototype.process = function(node) {
-    _.forEach(node.attributes, _.bind(this._processAttribute, this));
+    switch(node.type) {
+    case 'MustacheStatement':
+      this._processMustacheStatement(node);
+      break;
+    case 'ElementNode':
+      _.forEach(node.attributes, _.bind(this._processAttribute, this));
+      break;
+    }
   };
 
   return LogQuotes;

--- a/lib/rules/lint-quotes.js
+++ b/lib/rules/lint-quotes.js
@@ -89,7 +89,7 @@ module.exports = function(addonContext) {
 
     return this.log({
       message: 'Quotes: you got ' + undesiredQouteStyle +
-        ' quotes when you set quotes style to ' + this.config.quotesType +
+        ' quotes when you set quotes style to be ' + this.config.quotesType +
         ' quotes',
       line: node.loc.start.line,
       column: node.loc.start.column,

--- a/lib/rules/lint-quotes.js
+++ b/lib/rules/lint-quotes.js
@@ -17,7 +17,6 @@
    * string -- `single` of `double` for enforce style
  */
 
-var calculateLocationDisplay = require('../helpers/calculate-location-display');
 var buildPlugin = require('./base');
 
 var SINGLE_QUOTES_NAME = 'single';
@@ -73,15 +72,19 @@ module.exports = function(addonContext) {
 
     if (!this.config.shouldTestQuoteType) {
       if (qouteCharacter === '"' || qouteCharacter === '\'') {
-        return '';
+        return null;
       } else {
-        return 'Quotes: you should use qoutes for HTML attributes ' +
-          calculateLocationDisplay(this.options.moduleName, attribute.loc.start);
+        return {
+          message: 'Quotes: you should use qoutes for HTML attributes',
+          line: attribute.loc.start.line,
+          column: attribute.loc.start.column,
+          source: source
+        };
       }
     }
 
     if (this.config.quoteCharacter === qouteCharacter) {
-      return '';
+      return null;
     }
 
     var undesiredQouteStyle = (
@@ -90,9 +93,14 @@ module.exports = function(addonContext) {
         SINGLE_QUOTES_NAME
     );
 
-    return 'Quotes: you got ' + undesiredQouteStyle +
-      ' qoutes for an attribute instead of ' + this.config.quotesType +
-      ' qoutes ' + calculateLocationDisplay(this.options.moduleName, attribute.loc.start);
+    return {
+      message: 'Quotes: you got ' + undesiredQouteStyle +
+        ' qoutes for an attribute instead of ' + this.config.quotesType +
+        ' qoutes',
+      line: attribute.loc.start.line,
+      column: attribute.loc.start.column,
+      source: source
+    };
   };
 
   function filterEmptyErrorMessage(errorMessage) {

--- a/lib/rules/lint-quotes.js
+++ b/lib/rules/lint-quotes.js
@@ -17,6 +17,7 @@
    * string -- `single` of `double` for enforce style
  */
 
+var _ = require('lodash');
 var buildPlugin = require('./base');
 
 var SINGLE_QUOTES_NAME = 'single';
@@ -59,32 +60,30 @@ module.exports = function(addonContext) {
     );
   };
 
-  function filterAttribute(attribute) {
-    return (
-      attribute.value.type === 'TextNode' &&
-      attribute.value.chars.length > 0
-    );
-  }
+  LogQuotes.prototype._processAttributeTextNode = function(attribute) {
+    if (attribute.value.chars.length === 0) {
+      return;
+    }
 
-  LogQuotes.prototype._processAttribute = function(attribute) {
     var source = this.sourceForNode(attribute);
     var qouteCharacter = source[source.length - 1];
 
     if (!this.config.shouldTestQuoteType) {
       if (qouteCharacter === '"' || qouteCharacter === '\'') {
-        return null;
+        return;
       } else {
-        return {
+        this.log({
           message: 'Quotes: you should use qoutes for HTML attributes',
           line: attribute.loc.start.line,
           column: attribute.loc.start.column,
           source: source
-        };
+        });
+        return;
       }
     }
 
     if (this.config.quoteCharacter === qouteCharacter) {
-      return null;
+      return;
     }
 
     var undesiredQouteStyle = (
@@ -93,26 +92,86 @@ module.exports = function(addonContext) {
         SINGLE_QUOTES_NAME
     );
 
-    return {
+    this.log({
       message: 'Quotes: you got ' + undesiredQouteStyle +
         ' qoutes for an attribute instead of ' + this.config.quotesType +
         ' qoutes',
       line: attribute.loc.start.line,
       column: attribute.loc.start.column,
       source: source
-    };
+    });
+    return;
   };
 
-  function filterEmptyErrorMessage(errorMessage) {
-    return !!errorMessage;
-  }
+  LogQuotes.prototype._processNode = function(node) {
+    var source = this.sourceForNode(node);
+    var qouteCharacter = source[source.length - 1];
+
+    if (!this.config.shouldTestQuoteType) {
+      if (qouteCharacter === '"' || qouteCharacter === '\'') {
+        return;
+      } else {
+        return this.log({
+          message: 'Quotes: you should use quotes for attributes',
+          line: node.loc.start.line,
+          column: node.loc.start.column,
+          source: source
+        });
+      }
+    }
+
+    if (this.config.quoteCharacter === qouteCharacter) {
+      return;
+    }
+
+    var undesiredQouteStyle = (
+      this.config.quotesType === SINGLE_QUOTES_NAME ?
+        DOUBLE_QUOTES_NAME :
+        SINGLE_QUOTES_NAME
+    );
+
+    return this.log({
+      message: 'Quotes: you got ' + undesiredQouteStyle +
+        ' quotes when you set quotes style to ' + this.config.quotesType +
+        ' quotes',
+      line: node.loc.start.line,
+      column: node.loc.start.column,
+      source: source
+    });
+  };
+
+  LogQuotes.prototype._processAttributeMustacheStatement = function(node) {
+    var processNode = _.bind(function(node) {
+      switch(node.type) {
+      case 'StringLiteral':
+        this._processNode(node);
+        break;
+      case 'SubExpression':
+        this._processAttributeMustacheStatement(node);
+        break;
+      }
+    }, this);
+
+    _([])
+      .concat(node.params)
+      .concat(_.map(node.hash.pairs, 'value'))
+      .forEach(processNode);
+  };
+
+  LogQuotes.prototype._processAttribute = function(attribute) {
+    switch(attribute.value.type) {
+    case 'TextNode':
+      return this._processAttributeTextNode(attribute);
+    case 'MustacheStatement':
+      return this._processAttributeMustacheStatement(attribute.value);
+    // case 'ConcatStatement':
+    default:
+      return null;
+    }
+  };
 
   LogQuotes.prototype.process = function(node) {
-    node.attributes
-      .filter(filterAttribute)
-      .map(this._processAttribute, this)
-      .filter(filterEmptyErrorMessage)
-      .map(this.log, this);
+    _.forEach(node.attributes, _.bind(this._processAttribute, this));
   };
 
   return LogQuotes;

--- a/lib/rules/lint-quotes.js
+++ b/lib/rules/lint-quotes.js
@@ -60,7 +60,7 @@ module.exports = function(addonContext) {
     );
   };
 
-  LogQuotes.prototype._processNode = function(node, source) {
+  LogQuotes.prototype._processStringLiteralNode = function(node, source) {
     source = _.isString(source) ? source : this.sourceForNode(node);
     var qouteCharacter = source[source.length - 1];
 
@@ -99,7 +99,7 @@ module.exports = function(addonContext) {
 
   LogQuotes.prototype._processTextNode = function(node) {
     if (node.value.chars.length > 0) {
-      this._processNode(node, this.sourceForNode(node));
+      this._processStringLiteralNode(node, this.sourceForNode(node));
     }
   };
 
@@ -107,7 +107,7 @@ module.exports = function(addonContext) {
     var processNode = _.bind(function(node) {
       switch(node.type) {
       case 'StringLiteral':
-        this._processNode(node);
+        this._processStringLiteralNode(node);
         break;
       case 'SubExpression':
         this._processMustacheStatement(node);

--- a/lib/rules/lint-quotes.js
+++ b/lib/rules/lint-quotes.js
@@ -53,13 +53,6 @@ module.exports = function(addonContext) {
     throw new Error(errorMessage);
   };
 
-  LogQuotes.prototype.detect = function(node) {
-    return (
-      (node.type === 'MustacheStatement') ||
-      (node.type === 'ElementNode' && node.attributes.length > 0)
-    );
-  };
-
   LogQuotes.prototype._processStringLiteralNode = function(node, source) {
     source = _.isString(source) ? source : this.sourceForNode(node);
     var qouteCharacter = source[source.length - 1];
@@ -124,8 +117,6 @@ module.exports = function(addonContext) {
   LogQuotes.prototype._processConcatStatement = function(node) {
     // NOTE: check if there is no more reasonable solution
     this._processStringLiteralNode(node, this.sourceForNode(node));
-
-    _.forEach(node.value.parts, _.bind(this._processMustacheStatement, this));
   };
 
   LogQuotes.prototype._processAttribute = function(node) {
@@ -133,24 +124,24 @@ module.exports = function(addonContext) {
     case 'TextNode':
       this._processTextNode(node);
       break;
-    case 'MustacheStatement':
-      this._processMustacheStatement(node.value);
-      break;
     case 'ConcatStatement':
       this._processConcatStatement(node);
       break;
     }
   };
 
-  LogQuotes.prototype.process = function(node) {
-    switch(node.type) {
-    case 'MustacheStatement':
-      this._processMustacheStatement(node);
-      break;
-    case 'ElementNode':
-      _.forEach(node.attributes, _.bind(this._processAttribute, this));
-      break;
-    }
+  LogQuotes.prototype.visitors = function() {
+    var pluginContext = this;
+
+    return {
+      MustacheStatement: function(node) {
+        pluginContext._processMustacheStatement(node);
+      },
+
+      AttrNode: function(node) {
+        pluginContext._processAttribute(node);
+      }
+    };
   };
 
   return LogQuotes;

--- a/lib/rules/lint-quotes.js
+++ b/lib/rules/lint-quotes.js
@@ -121,6 +121,13 @@ module.exports = function(addonContext) {
       .forEach(processNode);
   };
 
+  LogQuotes.prototype._processConcatStatement = function(node) {
+    // NOTE: check if there is no more reasonable solution
+    this._processStringLiteralNode(node, this.sourceForNode(node));
+
+    _.forEach(node.value.parts, _.bind(this._processMustacheStatement, this));
+  };
+
   LogQuotes.prototype._processAttribute = function(node) {
     switch(node.value.type) {
     case 'TextNode':
@@ -130,7 +137,7 @@ module.exports = function(addonContext) {
       this._processMustacheStatement(node.value);
       break;
     case 'ConcatStatement':
-      _.forEach(node.value.parts, _.bind(this._processMustacheStatement, this));
+      this._processConcatStatement(node);
       break;
     }
   };

--- a/lib/rules/lint-quotes.js
+++ b/lib/rules/lint-quotes.js
@@ -1,0 +1,111 @@
+'use strict';
+
+/*
+ Enforce quotes style
+
+ ```
+ {{! good }}
+ <img alt="tomster" src="tomster.jpg">
+
+ {{! bad}}
+ <img alt='tomster' src="tomster.jpg">
+ ```
+
+ The following values are valid configuration:
+
+   * boolean -- `false` for disabled. `true` to enforce any qoutes
+   * string -- `single` of `double` for enforce style
+ */
+
+var calculateLocationDisplay = require('../helpers/calculate-location-display');
+var buildPlugin = require('./base');
+
+var SINGLE_QUOTES_NAME = 'single';
+var DOUBLE_QUOTES_NAME = 'double';
+
+module.exports = function(addonContext) {
+  var LogQuotes = buildPlugin(addonContext, 'quotes');
+
+  LogQuotes.prototype.parseConfig = function(config) {
+    if (config === false || config === undefined) {
+      return false;
+    }
+
+    if (config === true) {
+      return {
+        shouldTestQuoteType: false
+      };
+    }
+
+    if (config === SINGLE_QUOTES_NAME || config === DOUBLE_QUOTES_NAME) {
+      return {
+        shouldTestQuoteType: true,
+        quotesType: config,
+        quoteCharacter: config === SINGLE_QUOTES_NAME ? '\'' : '"'
+      };
+    }
+
+    var errorMessage = 'The quotes rule accepts one of the following values.\n ' +
+      '  * boolean -- `false` to disable\n' +
+      '  * string -- `' + SINGLE_QUOTES_NAME + '` of `' + DOUBLE_QUOTES_NAME +'` for enforce style\n' +
+      '\nYou specified `' + JSON.stringify(config) + '`';
+
+    throw new Error(errorMessage);
+  };
+
+  LogQuotes.prototype.detect = function(node) {
+    return (
+      node.type === 'ElementNode' &&
+      node.attributes.length > 0
+    );
+  };
+
+  function filterAttribute(attribute) {
+    return (
+      attribute.value.type === 'TextNode' &&
+      attribute.value.chars.length > 0
+    );
+  }
+
+  LogQuotes.prototype._processAttribute = function(attribute) {
+    var source = this.sourceForNode(attribute);
+    var qouteCharacter = source[source.length - 1];
+
+    if (!this.config.shouldTestQuoteType) {
+      if (qouteCharacter === '"' || qouteCharacter === '\'') {
+        return '';
+      } else {
+        return 'Quotes: you should use qoutes for HTML attributes ' +
+          calculateLocationDisplay(this.options.moduleName, attribute.loc.start);
+      }
+    }
+
+    if (this.config.quoteCharacter === qouteCharacter) {
+      return '';
+    }
+
+    var undesiredQouteStyle = (
+      this.config.quotesType === SINGLE_QUOTES_NAME ?
+        DOUBLE_QUOTES_NAME :
+        SINGLE_QUOTES_NAME
+    );
+
+    return 'Quotes: you got ' + undesiredQouteStyle +
+      ' qoutes for an attribute instead of ' + this.config.quotesType +
+      ' qoutes ' + calculateLocationDisplay(this.options.moduleName, attribute.loc.start);
+  };
+
+  function filterEmptyErrorMessage(errorMessage) {
+    return !!errorMessage;
+  }
+
+  LogQuotes.prototype.process = function(node) {
+    node.attributes
+      .filter(filterAttribute)
+      .map(this._processAttribute, this)
+      .filter(filterEmptyErrorMessage)
+      .map(this.log, this);
+  };
+
+  return LogQuotes;
+};

--- a/lib/rules/lint-quotes.js
+++ b/lib/rules/lint-quotes.js
@@ -130,7 +130,7 @@ module.exports = function(addonContext) {
       this._processMustacheStatement(node.value);
       break;
     case 'ConcatStatement':
-      /** @todo */
+      _.forEach(node.value.parts, _.bind(this._processMustacheStatement, this));
       break;
     }
   };

--- a/lib/rules/lint-quotes.js
+++ b/lib/rules/lint-quotes.js
@@ -47,7 +47,7 @@ module.exports = function(addonContext) {
 
     var errorMessage = 'The quotes rule accepts one of the following values.\n ' +
       '  * boolean -- `false` to disable\n' +
-      '  * string -- `' + SINGLE_QUOTES_NAME + '` of `' + DOUBLE_QUOTES_NAME +'` for enforce style\n' +
+      '  * string -- `' + SINGLE_QUOTES_NAME + '` of `' + DOUBLE_QUOTES_NAME + '` for enforce style\n' +
       '\nYou specified `' + JSON.stringify(config) + '`';
 
     throw new Error(errorMessage);

--- a/test/unit/plugins/lint-quotes-test.js
+++ b/test/unit/plugins/lint-quotes-test.js
@@ -70,6 +70,24 @@ generateRuleTests({
         line: 1,
         column: 5
       }
+    }, {
+      config: 'single',
+      template: '<img alt={{url "tomster"}}>',
+      result: {
+        message: 'Quotes: you got double quotes when you set quotes style to be single quotes',
+        source: '"tomster"',
+        line: 1,
+        column: 15
+      }
+    }, {
+      config: 'single',
+      template: '<img alt={{url local="tomster"}}>',
+      result: {
+        message: 'Quotes: you got double quotes when you set quotes style to be single quotes',
+        source: '"tomster"',
+        line: 1,
+        column: 21
+      }
     }
   ]
 });

--- a/test/unit/plugins/lint-quotes-test.js
+++ b/test/unit/plugins/lint-quotes-test.js
@@ -29,15 +29,30 @@ generateRuleTests({
     {
       config: true,
       template: '<img alt=tomster>',
-      message: 'Quotes: you should use qoutes for HTML attributes (\'layout.hbs\'@ L1:C6)'
+      result: {
+        message: 'Quotes: you should use qoutes for HTML attributes',
+        source: 'alt=tomster',
+        line: 1,
+        column: 5
+      }
     }, {
       config: 'double',
       template: '<img alt=\'tomster\'>',
-      message: 'Quotes: you got single qoutes for an attribute instead of double qoutes (\'layout.hbs\'@ L1:C6)'
+      result: {
+        message: 'Quotes: you got single qoutes for an attribute instead of double qoutes',
+        source: 'alt=\'tomster\'',
+        line: 1,
+        column: 5
+      }
     }, {
       config: 'single',
       template: '<img alt="tomster">',
-      message: 'Quotes: you got double qoutes for an attribute instead of single qoutes (\'layout.hbs\'@ L1:C6)'
+      result: {
+        message: 'Quotes: you got double qoutes for an attribute instead of single qoutes',
+        source: 'alt="tomster"',
+        line: 1,
+        column: 5
+      }
     }
   ]
 });

--- a/test/unit/plugins/lint-quotes-test.js
+++ b/test/unit/plugins/lint-quotes-test.js
@@ -88,6 +88,15 @@ generateRuleTests({
         line: 1,
         column: 21
       }
+    }, {
+      config: 'single',
+      template: '<img alt={{url (local "tomster")}}>',
+      result: {
+        message: 'Quotes: you got double quotes when you set quotes style to be single quotes',
+        source: '"tomster"',
+        line: 1,
+        column: 22
+      }
     }
   ]
 });

--- a/test/unit/plugins/lint-quotes-test.js
+++ b/test/unit/plugins/lint-quotes-test.js
@@ -47,7 +47,7 @@ generateRuleTests({
       config: true,
       template: '<img alt=tomster>',
       result: {
-        message: 'Quotes: you should use qoutes for HTML attributes',
+        message: 'Quotes: you should use quotes for attributes',
         source: 'alt=tomster',
         line: 1,
         column: 5
@@ -56,7 +56,7 @@ generateRuleTests({
       config: 'double',
       template: '<img alt=\'tomster\'>',
       result: {
-        message: 'Quotes: you got single qoutes for an attribute instead of double qoutes',
+        message: 'Quotes: you got single quotes when you set quotes style to double quotes',
         source: 'alt=\'tomster\'',
         line: 1,
         column: 5
@@ -65,7 +65,7 @@ generateRuleTests({
       config: 'single',
       template: '<img alt="tomster">',
       result: {
-        message: 'Quotes: you got double qoutes for an attribute instead of single qoutes',
+        message: 'Quotes: you got double quotes when you set quotes style to single quotes',
         source: 'alt="tomster"',
         line: 1,
         column: 5

--- a/test/unit/plugins/lint-quotes-test.js
+++ b/test/unit/plugins/lint-quotes-test.js
@@ -97,6 +97,24 @@ generateRuleTests({
         line: 1,
         column: 22
       }
+    }, {
+      config: 'single',
+      template: '<img alt="{{url \'tomster\'}}">',
+      result: {
+        message: 'Quotes: you got double quotes when you set quotes style to be single quotes',
+        source: 'alt="{{url \'tomster\'}}"',
+        line: 1,
+        column: 5
+      }
+    }, {
+      config: 'single',
+      template: '<img alt=\'{{url "tomster"}}\'>',
+      result: {
+        message: 'Quotes: you got double quotes when you set quotes style to be single quotes',
+        source: '"tomster"',
+        line: 1,
+        column: 16
+      }
     }
   ]
 });

--- a/test/unit/plugins/lint-quotes-test.js
+++ b/test/unit/plugins/lint-quotes-test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'quotes',
+
+  good: [
+    {
+      config: true,
+      template: '<img alt=\'tomster\' src="tomster.png">'
+    }, {
+      config: 'double',
+      template: '<img alt="tomster" src="tomster.png">'
+    }, {
+      config: 'single',
+      template: '<img alt=\'tomster\' src=\'tomster.png\'>'
+    }, {
+      config: 'double',
+      template: '<img alt src="tomster.png">'
+    // TODO:
+    // }, {
+    //   config: 'double',
+    //   template: '<img alt src=tomster.png>'
+    }
+  ],
+
+  bad: [
+    {
+      config: true,
+      template: '<img alt=tomster>',
+      message: 'Quotes: you should use qoutes for HTML attributes (\'layout.hbs\'@ L1:C6)'
+    }, {
+      config: 'double',
+      template: '<img alt=\'tomster\'>',
+      message: 'Quotes: you got single qoutes for an attribute instead of double qoutes (\'layout.hbs\'@ L1:C6)'
+    }, {
+      config: 'single',
+      template: '<img alt="tomster">',
+      message: 'Quotes: you got double qoutes for an attribute instead of single qoutes (\'layout.hbs\'@ L1:C6)'
+    }
+  ]
+});

--- a/test/unit/plugins/lint-quotes-test.js
+++ b/test/unit/plugins/lint-quotes-test.js
@@ -18,10 +18,6 @@ generateRuleTests({
     }, {
       config: 'double',
       template: '<img alt src="tomster.png">'
-    // TODO:
-    // }, {
-    //   config: 'double',
-    //   template: '<img alt src=tomster.png>'
     }
   ],
 

--- a/test/unit/plugins/lint-quotes-test.js
+++ b/test/unit/plugins/lint-quotes-test.js
@@ -56,7 +56,7 @@ generateRuleTests({
       config: 'double',
       template: '<img alt=\'tomster\'>',
       result: {
-        message: 'Quotes: you got single quotes when you set quotes style to double quotes',
+        message: 'Quotes: you got single quotes when you set quotes style to be double quotes',
         source: 'alt=\'tomster\'',
         line: 1,
         column: 5
@@ -65,7 +65,7 @@ generateRuleTests({
       config: 'single',
       template: '<img alt="tomster">',
       result: {
-        message: 'Quotes: you got double quotes when you set quotes style to single quotes',
+        message: 'Quotes: you got double quotes when you set quotes style to be single quotes',
         source: 'alt="tomster"',
         line: 1,
         column: 5

--- a/test/unit/plugins/lint-quotes-test.js
+++ b/test/unit/plugins/lint-quotes-test.js
@@ -115,6 +115,15 @@ generateRuleTests({
         line: 1,
         column: 16
       }
+    }, {
+      config: 'single',
+      template: '{{url "tomster"}}',
+      result: {
+        message: 'Quotes: you got double quotes when you set quotes style to be single quotes',
+        source: '"tomster"',
+        line: 1,
+        column: 6
+      }
     }
   ]
 });

--- a/test/unit/plugins/lint-quotes-test.js
+++ b/test/unit/plugins/lint-quotes-test.js
@@ -20,25 +20,25 @@ generateRuleTests({
       template: '<img alt src="tomster.png">'
     }, {
       config: 'double',
-      template: '<img alt src={{url-for-tomster}}>'
+      template: '<img alt src={{url-tomster}}>'
     }, {
       config: 'double',
-      template: '<img alt src={{url-for "tomster"}}>'
+      template: '<img alt src={{url "tomster"}}>'
     }, {
       config: 'double',
-      template: '<img alt src={{url-for img="tomster"}}>'
+      template: '<img alt src={{url img="tomster"}}>'
     }, {
       config: 'double',
-      template: '<img alt src={{url-for (inner-helper "tomster")}}>'
+      template: '<img alt src={{url (inner-helper "tomster")}}>'
     }, {
       config: 'double',
-      template: '<img alt src={{url-for hash-param=(inner-helper "tomster")}}>'
+      template: '<img alt src={{url hash-param=(inner-helper "tomster")}}>'
     }, {
       config: 'double',
-      template: '<img alt src="{{url-for "tomster"}}">'
+      template: '<img alt src="{{url "tomster"}}">'
     }, {
       config: 'double',
-      template: '{{url-for "tomster"}}'
+      template: '{{url "tomster"}}'
     }
   ],
 

--- a/test/unit/plugins/lint-quotes-test.js
+++ b/test/unit/plugins/lint-quotes-test.js
@@ -18,6 +18,27 @@ generateRuleTests({
     }, {
       config: 'double',
       template: '<img alt src="tomster.png">'
+    }, {
+      config: 'double',
+      template: '<img alt src={{url-for-tomster}}>'
+    }, {
+      config: 'double',
+      template: '<img alt src={{url-for "tomster"}}>'
+    }, {
+      config: 'double',
+      template: '<img alt src={{url-for img="tomster"}}>'
+    }, {
+      config: 'double',
+      template: '<img alt src={{url-for (inner-helper "tomster")}}>'
+    }, {
+      config: 'double',
+      template: '<img alt src={{url-for hash-param=(inner-helper "tomster")}}>'
+    }, {
+      config: 'double',
+      template: '<img alt src="{{url-for "tomster"}}">'
+    }, {
+      config: 'double',
+      template: '{{url-for "tomster"}}'
     }
   ],
 


### PR DESCRIPTION
[the original PR from ember-cli-template-lint](https://github.com/rwjblue/ember-cli-template-lint/pull/88)
#### config:
- `false` - disable
- `true` - only require qoutes for HTML attributes 
- `"single"` - always single quotes
- `"double"` - always double quotes
- `["single", "avoidEscape"]` - prefer single quotes unless there is an escape needed only to single quotes
- `["double", "avoidEscape"]` - prefer double quotes unless there is an escape needed only to double quotes
#### todos:
- [x] adding support for HTML attributes (TextNode)
- ~~adding support for HTMLBars helper attributes~~
- [x] attribute MustacheStatement
- [x] attribute ConcatStatement
- [x] MustacheStatement not inside attribute
- ~~ConcatStatement not inside attribute~~
- [x] adding support for only requiring qoutes
- [ ] adding README / and to blueprints
- [ ] adding avoidEscape supports
- [ ] adding avoidEscape to README

if i miss something, please tell me
