### PR TITLE
Add ability to mark specific rules as pending.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,9 @@ var compile = require('htmlbars').compile;
 var plugins = require('./rules');
 var getConfig = require('./get-config');
 
+var WARNING_SEVERITY = 1;
+var ERROR_SEVERITY = 2;
+
 function Linter(_options) {
   var options = _options || {};
 
@@ -18,9 +21,22 @@ Linter.prototype = {
     this.config = getConfig(this.options);
   },
 
+  _defaultSeverityForRule: function(ruleName, pendingStatus) {
+    if (typeof pendingStatus === 'boolean') {
+      return pendingStatus ? WARNING_SEVERITY : ERROR_SEVERITY;
+    } else if (pendingStatus.only){
+      if (pendingStatus.only.indexOf(ruleName) > -1) {
+        return WARNING_SEVERITY;
+      } else {
+        return ERROR_SEVERITY;
+      }
+    }
+
+    return 2;
+  },
+
   buildASTPlugins: function(config) {
     var results = config.results;
-    var defaultSeverity = config.pending ? 1 : 2;
 
     function addToResults(result) {
       results.push(result);
@@ -28,11 +44,12 @@ Linter.prototype = {
 
     var astPlugins = [];
     for (var pluginName in plugins) {
+
       var plugin = plugins[pluginName]({
         name: pluginName,
         config: this.config.rules[pluginName],
         log: addToResults,
-        defaultSeverity: defaultSeverity
+        defaultSeverity: this._defaultSeverityForRule(pluginName, config.pending)
       });
 
       astPlugins.push(plugin);
@@ -41,17 +58,28 @@ Linter.prototype = {
     return astPlugins;
   },
 
-  isPending: function(moduleId) {
-    return this.config.pending.indexOf(moduleId) > -1;
+  pendingStatusForModule: function(moduleId) {
+    var pendingList = this.config.pending;
+    for (var i = 0; i < pendingList.length; i++) {
+      var item = pendingList[i];
+
+      if (typeof item === 'string' && moduleId === item) {
+        return true;
+      } else if (item.moduleId === moduleId){
+        return item;
+      }
+    }
+
+    return false;
   },
 
   verify: function(options) {
     var messages = [];
-    var moduleIsPending = this.isPending(options.moduleId);
+    var pendingStatus = this.pendingStatusForModule(options.moduleId);
 
     var pluginConfig = {
       results: messages,
-      pending: moduleIsPending
+      pending: pendingStatus
     };
 
     try {
@@ -72,7 +100,7 @@ Linter.prototype = {
       });
     }
 
-    if (moduleIsPending && messages.length === 0) {
+    if (pendingStatus && messages.length === 0) {
       messages.push({
         message: 'Pending module (`' + options.moduleId + '`) passes all rules. Please remove `' + options.moduleId + '` from pending list.',
         moduleId: options.moduleId,


### PR DESCRIPTION
A `pending` listing of the following will only mark the `bare-strings` rule as "pending" for the `app-name/templates/foo` template:

```js
pending: [
  { moduleId: 'app-name/templates/foo', only: ['bare-strings']}
]
```

Fixes #47.