### PR TITLE
Update nested-interactive rule to use `isInteractiveElement` helper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,20 +191,11 @@ This rule forbids the following:
 The following values are valid configuration:
 
   * boolean -- `true` indicates all whitelist test will run, `false` indicates that the rule is disabled.
-  * array -- an array of whitelisted tests as the following
-
-Whitelist of option in the configuration (are tags name or element attributes):
-
-  * `button`
-  * `details`
-  * `embed`
-  * `iframe`
-  * `img`
-  * `input`
-  * `object`
-  * `select`
-  * `textarea`
-  * `tabindex`
+  * object - Containing the following values:
+    * `ignoredTags` - An array of element tag names that should be whitelisted. Default to `[]`.
+    * `ignoreTabindex` - When `true` tabindex will be ignored. Defaults to `false`.
+    * `ignoreUsemapAttribute` - When `true` ignores the `usemap` attribute on `img` and `object` elements. Defaults `false`.
+    * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.'
 
 ### Deprecations
 

--- a/lib/helpers/ast-node-info.js
+++ b/lib/helpers/ast-node-info.js
@@ -16,6 +16,10 @@ function isElementNode(node) {
   return node && node.type === 'ElementNode';
 }
 
+function isComponentNode(node) {
+  return node && node.type === 'ComponentNode';
+}
+
 function isBlockStatement(node) {
   return node.type === 'BlockStatement';
 }
@@ -42,6 +46,7 @@ module.exports = {
   isNonConfigurationHtmlComment: isNonConfigurationHtmlComment,
   isTextNode: isTextNode,
   isElementNode: isElementNode,
+  isComponentNode: isComponentNode,
   isBlockStatement: isBlockStatement,
   hasAttribute: hasAttribute,
   findAttribute: findAttribute

--- a/lib/helpers/is-interactive-element.js
+++ b/lib/helpers/is-interactive-element.js
@@ -36,8 +36,7 @@ function isHiddenInput(node) {
  there is a need to use it nested with `<object>` and `<a>`
  */
 function reason(node) {
-
-  if (!ast.isElementNode(node)) {
+  if (!ast.isElementNode(node) && !ast.isComponentNode(node)) {
     return null;
   }
 

--- a/lib/helpers/is-interactive-element.js
+++ b/lib/helpers/is-interactive-element.js
@@ -50,7 +50,7 @@ function reason(node) {
   }
 
   if (isHyperLink(node)) {
-    return '<a> with `href` attribute';
+    return 'an <a> element with the `href` attribute';
   }
 
   if (ast.hasAttribute(node, 'tabindex')) {
@@ -58,7 +58,7 @@ function reason(node) {
   }
 
   if ((node.tag === 'img' || node.tag === 'object') && ast.hasAttribute(node, 'usemap')) {
-    return '<' + node.tag + '> with `usemap` attribute';
+    return 'an <' + node.tag + '> element with the `usemap` attribute';
   }
 
   return null;

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -27,10 +27,10 @@ module.exports = function(options) {
     // split into a source array (allow windows and posix line endings)
     this.source = this.options.rawSource.split(/(?:\r\n?|\n)/g);
 
+    this._log = log;
     this.ruleName = ruleName;
     this.severity = defaultSeverity;
     this.config = this.parseConfig(config);
-    this._log = log;
   }
 
   BasePlugin.prototype.parseConfig = function(config) {

--- a/lib/rules/lint-nested-interactive.js
+++ b/lib/rules/lint-nested-interactive.js
@@ -44,6 +44,31 @@ function configValid(config) {
   return true;
 }
 
+function convertConfigArrayToObject(config) {
+  var base = {
+    ignoredTags: [],
+    ignoreTabindex: false,
+    ignoreUsemapAttribute: false
+  };
+
+  for (var i = 0; i < config.length; i++) {
+    var value = config[i];
+
+    switch (value) {
+    case 'tabindex':
+      base.ignoreTabindex = true;
+      break;
+    case 'usemap':
+      base.ignoreUsemapAttribute = true;
+      break;
+    default:
+      base.ignoredTags.push(value);
+    }
+  }
+
+  return base;
+}
+
 module.exports = function(addonContext) {
   var LogNestedInteractive = buildPlugin(addonContext, 'nested-interactive');
 
@@ -67,6 +92,8 @@ module.exports = function(addonContext) {
     case 'object':
       if (configValid(config)) {
         return config;
+      } else if (Array.isArray(config)) {
+        return convertConfigArrayToObject(config);
       } else {
         throw new Error(errorMessage);
       }

--- a/lib/rules/lint-nested-interactive.js
+++ b/lib/rules/lint-nested-interactive.js
@@ -19,6 +19,8 @@
 var buildPlugin = require('./base');
 var isInteractiveElement = require('../helpers/is-interactive-element');
 
+var ARRAY_DEPRECATION_MESSAGE = 'Specifying an array as the configurate for the `nested-interactive` rule is deprecated and will be removed in future versions.  Please update `.template-lintrc.js` to use the newer object format.';
+
 function configValid(config) {
   for (var key in config) {
     var value = config[key];
@@ -93,6 +95,11 @@ module.exports = function(addonContext) {
       if (configValid(config)) {
         return config;
       } else if (Array.isArray(config)) {
+        this.log({
+          message: ARRAY_DEPRECATION_MESSAGE,
+          source: JSON.stringify(config),
+          severity: 1
+        });
         return convertConfigArrayToObject(config);
       } else {
         throw new Error(errorMessage);
@@ -200,3 +207,5 @@ module.exports = function(addonContext) {
 
   return LogNestedInteractive;
 };
+
+module.exports.ARRAY_DEPRECATION_MESSAGE = ARRAY_DEPRECATION_MESSAGE;

--- a/lib/rules/lint-nested-interactive.js
+++ b/lib/rules/lint-nested-interactive.js
@@ -19,21 +19,57 @@
 var buildPlugin = require('./base');
 var isInteractiveElement = require('../helpers/is-interactive-element');
 
+function configValid(config) {
+  for (var key in config) {
+    var value = config[key];
+
+    switch (key) {
+    case 'ignoredTags':
+    case 'additionalInteractiveTags':
+      if (!Array.isArray(value)) {
+        return false;
+      }
+      break;
+    case 'ignoreTabindex':
+    case 'ignoreUsemapAttribute':
+      if (typeof value !== 'boolean') {
+        return false;
+      }
+      break;
+    default:
+      return false;
+    }
+  }
+
+  return true;
+}
+
 module.exports = function(addonContext) {
   var LogNestedInteractive = buildPlugin(addonContext, 'nested-interactive');
 
   LogNestedInteractive.prototype.parseConfig = function(config) {
     var configType = typeof config;
 
-    var errorMessage = 'The nested-interactive rule accepts one of the following values.\n ' +
-          '  * boolean - `true` to enable / `false` to disable\n' +
-          '\nYou specified `' + JSON.stringify(config) + '`';
+    var errorMessage = [
+      'The nested-interactive rule accepts one of the following values.',
+      '  * boolean - `true` to enable / `false` to disable',
+      '  * object - Containing the following values:',
+      '    * `ignoredTags` - An array of element tag names that should be whitelisted. Default to `[]`.',
+      '    * `ignoreTabindex` - When `true` tabindex will be ignored. Defaults to `false`.',
+      '    * `ignoreUsemapAttribute` - When `true` ignores the `usemap` attribute on `img` and `object` elements. Defaults `false`.',
+      '    * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.',
+      'You specified `' + JSON.stringify(config) + '`'
+    ].join('\n');
 
     switch (configType) {
     case 'boolean':
       return config;
     case 'object':
-      throw new Error(errorMessage);
+      if (configValid(config)) {
+        return config;
+      } else {
+        throw new Error(errorMessage);
+      }
     case 'undefined':
       return false;
     default:
@@ -52,39 +88,85 @@ module.exports = function(addonContext) {
   LogNestedInteractive.prototype.visitors = function() {
     this._parentInteractiveNode = null;
 
-    return {
-      ElementNode: {
-        enter: function(node) {
-          if (this.isDisabled()) { return; }
+    var visitor = {
+      enter: function(node) {
+        var isInteractive = isInteractiveElement(node);
 
-          var isInteractive = isInteractiveElement(node);
+        if (this.isCustomInteractiveElement(node)) {
+          isInteractive = true;
+        }
 
-          if (!isInteractive) { return; }
+        if (!isInteractive) { return; }
+        if (this.isInteractiveExcluded(node)) { return; }
 
-          if (this._parentInteractiveNode) {
-            this.log({
-              message: this.getLogMessage(node, this._parentInteractiveNode),
-              line: node.loc && node.loc.start.line,
-              column: node.loc && node.loc.start.column,
-              source: this.sourceForNode(node)
-            });
-          } else {
-            this._parentInteractiveNode = node;
-          }
-        },
+        if (this._parentInteractiveNode) {
+          this.log({
+            message: this.getLogMessage(node, this._parentInteractiveNode),
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node)
+          });
+        } else {
+          this._parentInteractiveNode = node;
+        }
+      },
 
-        exit: function(node) {
-          if (this._parentInteractiveNode === node) {
-            this._parentInteractiveNode = null;
-          }
+      exit: function(node) {
+        if (this._parentInteractiveNode === node) {
+          this._parentInteractiveNode = null;
         }
       }
     };
+
+    return {
+      ElementNode: visitor,
+      ComponentNode: visitor
+    };
+  };
+
+  LogNestedInteractive.prototype.isCustomInteractiveElement = function(node) {
+
+    var additionalInteractiveTags = this.config.additionalInteractiveTags || [];
+
+    if (additionalInteractiveTags.indexOf(node.tag) > -1) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
+  LogNestedInteractive.prototype.isInteractiveExcluded = function(node) {
+    var reason = isInteractiveElement.reason(node);
+    var ignoredTags = this.config.ignoredTags || [];
+    var ignoreTabindex = this.config.ignoreTabindex;
+    var ignoreUsemapAttribute = this.config.ignoreUsemapAttribute;
+
+    if (ignoredTags.indexOf(node.tag) > -1) {
+      return true;
+    }
+
+    if (ignoreTabindex && reason.indexOf('tabindex') > -1) {
+      return true;
+    }
+
+    if (ignoreUsemapAttribute && reason.indexOf('usemap') > -1) {
+      return true;
+    }
   };
 
   LogNestedInteractive.prototype.getLogMessage = function(node, parentNode) {
     var parentReason = isInteractiveElement.reason(parentNode);
     var childReason = isInteractiveElement.reason(node);
+
+    // `reason` for `additionalInteractiveTags` would be `null`
+    // so we need to handle that and update the reason correctly
+    if (this.isCustomInteractiveElement(parentNode)) {
+      parentReason = '<' + parentNode.tag + '>';
+    }
+
+    if (this.isCustomInteractiveElement(node)) {
+      childReason = '<' + node.tag + '>';
+    }
 
     return 'Do not use ' + childReason + ' inside ' + parentReason;
   };

--- a/lib/rules/lint-nested-interactive.js
+++ b/lib/rules/lint-nested-interactive.js
@@ -17,31 +17,23 @@
  */
 
 var buildPlugin = require('./base');
+var isInteractiveElement = require('../helpers/is-interactive-element');
 
 module.exports = function(addonContext) {
   var LogNestedInteractive = buildPlugin(addonContext, 'nested-interactive');
-
-  function isElementNode(node) {
-    return node.type === 'ElementNode';
-  }
 
   LogNestedInteractive.prototype.parseConfig = function(config) {
     var configType = typeof config;
 
     var errorMessage = 'The nested-interactive rule accepts one of the following values.\n ' +
           '  * boolean - `true` to enable / `false` to disable\n' +
-          '  * array -- an array of strings to whitelist\n' +
           '\nYou specified `' + JSON.stringify(config) + '`';
 
     switch (configType) {
     case 'boolean':
       return config;
     case 'object':
-      if (Array.isArray(config)) {
-        return config;
-      } else {
-        throw new Error(errorMessage);
-      }
+      throw new Error(errorMessage);
     case 'undefined':
       return false;
     default:
@@ -53,207 +45,48 @@ module.exports = function(addonContext) {
     if (Array.isArray(this.config)) {
       return this.config;
     } else {
-      return [
-        'a',
-        'button',
-        'details',
-        'embed',
-        'iframe',
-        'img',
-        'input',
-        'object',
-        'select',
-        'tabindex',
-        'textarea'
-      ];
+      return [];
     }
   };
 
   LogNestedInteractive.prototype.visitors = function() {
-    var pluginContext = this;
-    pluginContext._parentInteractiveNode = null;
+    this._parentInteractiveNode = null;
 
     return {
-      CommentStatement: function(node) {
-        if (node.value.indexOf('template-lint') > -1) {
-          pluginContext._processConfigNode(node);
-        }
-      },
-
       ElementNode: {
         enter: function(node) {
-          if (pluginContext.isDisabled()) { return; }
+          if (this.isDisabled()) { return; }
 
-          var isInteractive = pluginContext.isInteractiveElement(node);
+          var isInteractive = isInteractiveElement(node);
 
           if (!isInteractive) { return; }
 
-          if (pluginContext._parentInteractiveNode) {
-            pluginContext.log({
-              message: pluginContext.getLogMessage(node, pluginContext._parentInteractiveNode),
+          if (this._parentInteractiveNode) {
+            this.log({
+              message: this.getLogMessage(node, this._parentInteractiveNode),
               line: node.loc && node.loc.start.line,
               column: node.loc && node.loc.start.column,
-              source: pluginContext.sourceForNode(node)
+              source: this.sourceForNode(node)
             });
           } else {
-            pluginContext._parentInteractiveNode = node;
+            this._parentInteractiveNode = node;
           }
         },
 
         exit: function(node) {
-          if (pluginContext._parentInteractiveNode === node) {
-            pluginContext._parentInteractiveNode = null;
+          if (this._parentInteractiveNode === node) {
+            this._parentInteractiveNode = null;
           }
         }
       }
     };
   };
 
-  LogNestedInteractive.prototype.hasNodeHaveAttribute = function(node, attributeName) {
-    return node.attributes.some(function(attribute) {
-      return attribute.name === attributeName;
-    });
-  };
-
-  LogNestedInteractive.prototype.isNodeLink = function(node, whitelistTests) {
-    return (
-      whitelistTests.indexOf('a') !== -1 &&
-      node.tag === 'a' && this.hasNodeHaveAttribute(node, 'href')
-    );
-  };
-
-  LogNestedInteractive.prototype.isNodeNotHiddenInput = function(node, whitelistTests) {
-    if (whitelistTests.indexOf('input') === -1) {
-      return false;
-    }
-
-    if (node.tag === 'input') {
-      var isInputTypeHidden = node.attributes.some(function(attribute) {
-        return (
-          attribute.name === 'type' &&
-          attribute.value &&
-          attribute.value.chars === 'hidden'
-        );
-      });
-
-      // NOTE: `!`
-      if (!isInputTypeHidden) {
-        return true;
-      }
-    }
-
-    return false;
-  };
-
-  LogNestedInteractive.prototype.hasNodeHaveTabIndex = function(node, whitelistTests) {
-    return (
-      whitelistTests.indexOf('tabindex') !== -1 &&
-      this.hasNodeHaveAttribute(node, 'tabindex')
-    );
-  };
-
-  LogNestedInteractive.prototype.isNodeUseMapInteractive = function(node, whitelistTests) {
-    return (
-      whitelistTests.indexOf(node.tag) !== -1 &&
-      (node.tag === 'img' || node.tag === 'object') &&
-      this.hasNodeHaveAttribute(node, 'usemap')
-    );
-  };
-
-  LogNestedInteractive.prototype.isNodeInteractiveTag = function(node, whitelistTests) {
-    var interactiveTags = [
-      'button',
-      'details',
-      'embed',
-      'iframe',
-      'select',
-      'textarea'
-    ];
-
-    return interactiveTags.some(function(tagName) {
-      return whitelistTests.indexOf(tagName) !== -1 && tagName === node.tag;
-    });
-  };
-
-  /**
-   * NOTE: `<label>` was omitted due to the ability nesting a label with an input tag.
-   * NOTE: `<audio>` and `<video>` also omitted because use legacy browser support
-   * there is a need to use it nested with `<object>` and `<a>`
-   */
-  LogNestedInteractive.prototype.isInteractiveElement = function(node) {
-    var whitelistTests = this.getConfigWhiteList();
-
-    if (!node) {
-      return false;
-    }
-
-    if (this.isNodeInteractiveTag(node, whitelistTests)) {
-      return true;
-    }
-
-    if (this.isNodeLink(node, whitelistTests)) {
-      return true;
-    }
-
-    if (this.isNodeNotHiddenInput(node, whitelistTests)) {
-      return true;
-    }
-
-    if (this.hasNodeHaveTabIndex(node, whitelistTests)) {
-      return true;
-    }
-
-    if (this.isNodeUseMapInteractive(node, whitelistTests)) {
-      return true;
-    }
-
-    return false;
-  };
-
-
   LogNestedInteractive.prototype.getLogMessage = function(node, parentNode) {
-    var isParentHasTabIndexAttribute = this.hasNodeHaveAttribute(parentNode, 'tabindex');
-    var isParentHasUseMapAttribute = this.hasNodeHaveAttribute(parentNode, 'usemap');
-    var parentNodeError = '<' + parentNode.tag + '>';
+    var parentReason = isInteractiveElement.reason(parentNode);
+    var childReason = isInteractiveElement.reason(node);
 
-    if (isParentHasTabIndexAttribute) {
-      parentNodeError = 'an element with attribute `tabindex`';
-    } else if (isParentHasUseMapAttribute) {
-      parentNodeError = 'an element with attribute `usemap`';
-    }
-
-    var isChildHasTabIndexAttribute = this.hasNodeHaveAttribute(node, 'tabindex');
-    var isChildHasUseMapAttribute = this.hasNodeHaveAttribute(node, 'usemap');
-    var childNodeError = '<' + node.tag + '>';
-
-    if (isChildHasTabIndexAttribute) {
-      childNodeError = 'an element with attribute `tabindex`';
-    } else if (isChildHasUseMapAttribute) {
-      childNodeError = 'an element with attribute `usemap`';
-    }
-
-    return 'Do not use ' + childNodeError + ' inside ' + parentNodeError;
-  };
-
-  LogNestedInteractive.prototype.findNestedInteractiveElements = function(node, parentInteractiveNode, whitelistTests) {
-    if (this.isInteractiveElement(parentInteractiveNode, whitelistTests)) {
-      if (this.isInteractiveElement(node, whitelistTests)) {
-        this.log({
-          message: this.getLogMessage(node, parentInteractiveNode),
-          line: node.loc && node.loc.start.line,
-          column: node.loc && node.loc.start.column,
-          source: this.sourceForNode(node)
-        });
-
-        return;
-      }
-    }
-
-    node.children
-      .filter(isElementNode)
-      .forEach(function(childNode) {
-        this.findNestedInteractiveElements(childNode, node, whitelistTests);
-      }, this);
+    return 'Do not use ' + childReason + ' inside ' + parentReason;
   };
 
   return LogNestedInteractive;

--- a/test/unit/is-interactive-element-test.js
+++ b/test/unit/is-interactive-element-test.js
@@ -31,7 +31,7 @@ describe('isInteractiveElement', function() {
   ];
 
   var interactive = {
-    '<a href="derp">Link</a>': '<a> with `href` attribute',
+    '<a href="derp">Link</a>': 'an <a> element with the `href` attribute',
     '<button>Derp</button>': '<button>',
     '<details></details>': '<details>',
     '<embed>': '<embed>',
@@ -39,8 +39,8 @@ describe('isInteractiveElement', function() {
     '<input>': '<input>',
     '<select></select>': '<select>',
     '<textarea></textarea>': '<textarea>',
-    '<img usemap="#foo">': '<img> with `usemap` attribute',
-    '<object usemap="#foo"></object>': '<object> with `usemap` attribute',
+    '<img usemap="#foo">': 'an <img> element with the `usemap` attribute',
+    '<object usemap="#foo"></object>': 'an <object> element with the `usemap` attribute',
     '<div tabindex=1></div>': 'an element with the `tabindex` attribute'
   };
 

--- a/test/unit/plugins/lint-nested-interactive-test.js
+++ b/test/unit/plugins/lint-nested-interactive-test.js
@@ -13,7 +13,27 @@ generateRuleTests({
     '<a><button>button</button></a>',
     '<a href="/">link</a>',
     '<a href="/">link <strong>!!!</strong></a>',
-    '<button><input type="hidden"></button>'
+    '<button><input type="hidden"></button>',
+    {
+      config: {
+        ignoredTags: ['button']
+      },
+      template: '<button><input></button>'
+    },
+    {
+      config: {
+        ignoreTabindex: true
+      },
+
+      template: '<button><div tabindex=-1></div></button>'
+    },
+    {
+      config: {
+        ignoreUsemapAttribute: true
+      },
+
+      template: '<button><img usemap=""></button>'
+    }
   ],
 
   bad: [
@@ -183,6 +203,21 @@ generateRuleTests({
         source: '<button></button>',
         line: 1,
         column: 18
+      }
+    },
+    {
+      config: {
+        additionalInteractiveTags: ['my-special-input']
+      },
+      template: '<button><my-special-input></my-special-input></button>',
+
+      result: {
+        rule: 'nested-interactive',
+        message: 'Do not use <my-special-input> inside <button>',
+        moduleId: 'layout.hbs',
+        source: '<my-special-input></my-special-input>',
+        line: 1,
+        column: 8
       }
     }
   ]

--- a/test/unit/plugins/lint-nested-interactive-test.js
+++ b/test/unit/plugins/lint-nested-interactive-test.js
@@ -33,6 +33,18 @@ generateRuleTests({
       },
 
       template: '<button><img usemap=""></button>'
+    },
+    {
+      config: ['button'],
+      template: '<button><input></button>'
+    },
+    {
+      config: ['tabindex'],
+      template: '<button><div tabindex=-1></div></button>'
+    },
+    {
+      config: ['usemap'],
+      template: '<button><img usemap=""></button>'
     }
   ],
 

--- a/test/unit/plugins/lint-nested-interactive-test.js
+++ b/test/unit/plugins/lint-nested-interactive-test.js
@@ -13,54 +13,16 @@ generateRuleTests({
     '<a><button>button</button></a>',
     '<a href="/">link</a>',
     '<a href="/">link <strong>!!!</strong></a>',
-    '<button><input type="hidden"></button>',
-    {
-      config: ['button', 'details', 'embed', 'iframe', 'img', 'input', 'object', 'select', 'tabindex', 'textarea'],
-      template: '<a href="/">button<a href="/">!</a></a>'
-    }, {
-      config: ['a', 'details', 'embed', 'iframe', 'img', 'input', 'object', 'select', 'tabindex', 'textarea'],
-      template: '<a href="/">button<button>!</button></a>'
-    }, {
-      config: ['a', 'details', 'embed', 'iframe', 'img', 'input', 'object', 'select', 'tabindex', 'textarea'],
-      template: '<button>button<button>!</button></button>'
-    }, {
-      config: ['a', 'button', 'details', 'embed', 'iframe', 'img', 'object', 'select', 'tabindex', 'textarea'],
-      template: '<button><input type="text"></button>'
-    }, {
-      config: ['a', 'button', 'embed', 'iframe', 'img', 'input', 'object', 'select', 'tabindex', 'textarea'],
-      template: '<button><details><summary>Some details</summary><p>!</p></details></button>'
-    }, {
-      config: ['a', 'button', 'details', 'iframe', 'img', 'input', 'object', 'select', 'tabindex', 'textarea'],
-      template: '<button><embed type="video/quicktime" src="movie.mov" width="640" height="480"></button>'
-    }, {
-      config: ['a', 'button', 'details', 'embed', 'img', 'input', 'object', 'select', 'tabindex', 'textarea'],
-      template: '<button><iframe src="/frame.html" width="640" height="480"></iframe></button>'
-    }, {
-      config: ['a', 'button', 'details', 'embed', 'iframe', 'img', 'input', 'object', 'tabindex', 'textarea'],
-      template: '<button><select></select></button>'
-    }, {
-      config: ['a', 'button', 'details', 'embed', 'iframe', 'img', 'input', 'object', 'select', 'tabindex'],
-      template: '<button><textarea></textarea></button>'
-    }, {
-      config: ['a', 'button', 'details', 'embed', 'iframe', 'img', 'input', 'object', 'select', 'textarea'],
-      template: '<div tabindex="1"><button></button></div>'
-    }, {
-      config: ['a', 'button', 'details', 'embed', 'iframe', 'input', 'object', 'select', 'tabindex', 'textarea'],
-      template: '<button><img usemap=""></button>'
-    }, {
-      config: ['a', 'button', 'details', 'embed', 'iframe', 'img', 'input', 'select', 'tabindex', 'textarea'],
-      template: '<object usemap=""><button></button></object>'
-    }
+    '<button><input type="hidden"></button>'
   ],
 
   bad: [
     {
-      config: ['a'],
       template: '<a href="/">button<a href="/">!</a></a>',
 
       result: {
         rule: 'nested-interactive',
-        message: 'Do not use <a> inside <a>',
+        message: 'Do not use an <a> element with the `href` attribute inside an <a> element with the `href` attribute',
         moduleId: 'layout.hbs',
         source: '<a href=\"/\">!</a>',
         line: 1,
@@ -68,12 +30,11 @@ generateRuleTests({
       }
     },
     {
-      config: ['a', 'button'],
       template: '<a href="/">button<button>!</button></a>',
 
       result: {
         rule: 'nested-interactive',
-        message: 'Do not use <button> inside <a>',
+        message: 'Do not use <button> inside an <a> element with the `href` attribute',
         moduleId: 'layout.hbs',
         source: '<button>!</button>',
         line: 1,
@@ -81,12 +42,11 @@ generateRuleTests({
       }
     },
     {
-      config: ['a', 'button'],
       template: '<button>button<a href="/">!</a></button>',
 
       result: {
         rule: 'nested-interactive',
-        message: 'Do not use <a> inside <button>',
+        message: 'Do not use an <a> element with the `href` attribute inside <button>',
         moduleId: 'layout.hbs',
         source: '<a href=\"/\">!</a>',
         line: 1,
@@ -94,7 +54,6 @@ generateRuleTests({
       }
     },
     {
-      config: ['button'],
       template: '<button>button<button>!</button></button>',
 
       result: {
@@ -107,7 +66,6 @@ generateRuleTests({
       }
     },
     {
-      config: ['button', 'input'],
       template: '<button><input type="text"></button>',
 
       result: {
@@ -120,7 +78,6 @@ generateRuleTests({
       }
     },
     {
-      config: ['button', 'details'],
       template: '<button><details><summary>Some details</summary><p>!</p></details></button>',
 
       result: {
@@ -133,7 +90,6 @@ generateRuleTests({
       }
     },
     {
-      config: ['button', 'embed'],
       template: '<button><embed type="video/quicktime" src="movie.mov" width="640" height="480"></button>',
 
       result: {
@@ -146,7 +102,6 @@ generateRuleTests({
       }
     },
     {
-      config: ['button', 'iframe'],
       template: '<button><iframe src="/frame.html" width="640" height="480"></iframe></button>',
 
       result: {
@@ -159,7 +114,6 @@ generateRuleTests({
       }
     },
     {
-      config: ['button', 'select'],
       template: '<button><select></select></button>',
 
       result: {
@@ -172,7 +126,6 @@ generateRuleTests({
       }
     },
     {
-      config: ['button', 'textarea'],
       template: '<button><textarea></textarea></button>',
 
       result: {
@@ -185,12 +138,11 @@ generateRuleTests({
       }
     },
     {
-      config: ['button', 'tabindex'],
       template: '<div tabindex="1"><button></button></div>',
 
       result: {
         rule: 'nested-interactive',
-        message: 'Do not use <button> inside an element with attribute `tabindex`',
+        message: 'Do not use <button> inside an element with the `tabindex` attribute',
         moduleId: 'layout.hbs',
         source: '<button></button>',
         line: 1,
@@ -198,12 +150,11 @@ generateRuleTests({
       }
     },
     {
-      config: ['button', 'tabindex'],
       template: '<button><div tabindex="1"></div></button>',
 
       result: {
         rule: 'nested-interactive',
-        message: 'Do not use an element with attribute `tabindex` inside <button>',
+        message: 'Do not use an element with the `tabindex` attribute inside <button>',
         moduleId: 'layout.hbs',
         source: '<div tabindex=\"1\"></div>',
         line: 1,
@@ -211,12 +162,11 @@ generateRuleTests({
       }
     },
     {
-      config: ['button', 'img'],
       template: '<button><img usemap=""></button>',
 
       result: {
         rule: 'nested-interactive',
-        message: 'Do not use an element with attribute `usemap` inside <button>',
+        message: 'Do not use an <img> element with the `usemap` attribute inside <button>',
         moduleId: 'layout.hbs',
         source: '<img usemap=\"\">',
         line: 1,
@@ -224,12 +174,11 @@ generateRuleTests({
       }
     },
     {
-      config: ['button', 'object'],
       template: '<object usemap=""><button></button></object>',
 
       result: {
         rule: 'nested-interactive',
-        message: 'Do not use <button> inside an element with attribute `usemap`',
+        message: 'Do not use <button> inside an <object> element with the `usemap` attribute',
         moduleId: 'layout.hbs',
         source: '<button></button>',
         line: 1,

--- a/test/unit/plugins/lint-nested-interactive-test.js
+++ b/test/unit/plugins/lint-nested-interactive-test.js
@@ -1,9 +1,11 @@
 'use strict';
 
 var generateRuleTests = require('../../helpers/rule-test-harness');
+var ARRAY_DEPRECATION_MESSAGE = require('../../../lib/rules/lint-nested-interactive').ARRAY_DEPRECATION_MESSAGE;
 
 generateRuleTests({
   name: 'nested-interactive',
+
 
   config: true,
 
@@ -32,18 +34,6 @@ generateRuleTests({
         ignoreUsemapAttribute: true
       },
 
-      template: '<button><img usemap=""></button>'
-    },
-    {
-      config: ['button'],
-      template: '<button><input></button>'
-    },
-    {
-      config: ['tabindex'],
-      template: '<button><div tabindex=-1></div></button>'
-    },
-    {
-      config: ['usemap'],
       template: '<button><img usemap=""></button>'
     }
   ],
@@ -230,6 +220,42 @@ generateRuleTests({
         source: '<my-special-input></my-special-input>',
         line: 1,
         column: 8
+      }
+    },
+
+    // deprecated
+    {
+      config: ['button'],
+      template: '<button><input></button>',
+
+      result: {
+        rule: 'nested-interactive',
+        message: ARRAY_DEPRECATION_MESSAGE,
+        source: '["button"]',
+        severity: 1
+      }
+    },
+    {
+      config: ['tabindex'],
+      template: '<button><div tabindex=-1></div></button>',
+
+      result: {
+        rule: 'nested-interactive',
+        message: ARRAY_DEPRECATION_MESSAGE,
+        moduleId: 'layout.hbs',
+        source: '["tabindex"]',
+        severity: 1
+      }
+    },
+    {
+      config: ['usemap'],
+      template: '<button><img usemap=""></button>',
+
+      result: {
+        rule: 'nested-interactive',
+        message: ARRAY_DEPRECATION_MESSAGE,
+        source: '["usemap"]',
+        severity: 1
       }
     }
   ]


### PR DESCRIPTION
Removes support for `nested-interactive` config to be an array. The
underlying functionality will be brought back before releasing.

I intend to change the configuration to use an object so that we can make it clearer what is being whitelisted. My current thoughts are something like:

```js
rules: {
  'nested-interactive': {
    ignoredTags: ['a', 'button'], // list of tag names to ignore
    ignoreTabindex: true, // ignore the tabindex check
    ignoreUsemapAttribute: ['img', 'object'], // ignore `usemap` check for specific tag names
    additionalInteractiveTags: ['some-custom-tag'], // not sure this is needed, but it seams neat :P
  }
}
```

I believe that we can convert the currently allowed array into the above object and issue a deprecation so we don't need a breaking change.