### PR TITLE
Add tests for indentation calculation for escaped curlies and raw blocks

### DIFF
--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -8,6 +8,16 @@ generateRuleTests({
   config: 2,
 
   good: [
+    [
+      '<div>',
+      '  \\{{example}}',
+      '</div>'
+    ].join('\n'),
+    [
+      '{{{{if isMorning}}}}',
+      '  Good Morning',
+      '{{{{/if}}}}'
+    ].join('\n'),
     '\n  {{#each cats as |dog|}}\n  {{/each}}',
     '<div><p>Stuff</p></div>',
     '<div>\n  <p>Stuff Here</p>\n</div>',


### PR DESCRIPTION
Fixes #54.

The following template:
```handlebars
<div>
  \{{example}}
</div>
```
caused the following error:
```
block-indentation: Incorrect indentation for `{{example}}
` beginning at L2:C3. Expected `{{example}}
` to be at an indentation of 2 but was found at 0.(dummy/pods/examples/computed-properties/any/template @ L2:C3): 
`<div>
  \{{example}}
</div>`
```

It seems like the indentation calculation is thrown off by the line starting with the sequence `\{{`.

The problem seemed to be due to the template compiler compiling `\n  ` and the following `{{example}}` into separate textNodes.