### PR TITLE
Ignore parent node's `tabindex` for `nested-interactive` rule.

### DIFF
--- a/lib/rules/lint-nested-interactive.js
+++ b/lib/rules/lint-nested-interactive.js
@@ -140,6 +140,10 @@ module.exports = function(addonContext) {
             column: node.loc && node.loc.start.column,
             source: this.sourceForNode(node)
           });
+        } else if (this.isInteractiveFromTabindex(node)) {
+          // do not consider a thing a "parent interactive node" for
+          // tabindex alone
+          return;
         } else {
           this._parentInteractiveNode = node;
         }
@@ -163,6 +167,16 @@ module.exports = function(addonContext) {
     var additionalInteractiveTags = this.config.additionalInteractiveTags || [];
 
     if (additionalInteractiveTags.indexOf(node.tag) > -1) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
+  LogNestedInteractive.prototype.isInteractiveFromTabindex = function(node) {
+    var reason = isInteractiveElement.reason(node);
+
+    if (reason && reason.indexOf('tabindex') > -1) {
       return true;
     } else {
       return false;

--- a/test/unit/plugins/lint-nested-interactive-test.js
+++ b/test/unit/plugins/lint-nested-interactive-test.js
@@ -6,7 +6,6 @@ var ARRAY_DEPRECATION_MESSAGE = require('../../../lib/rules/lint-nested-interact
 generateRuleTests({
   name: 'nested-interactive',
 
-
   config: true,
 
   good: [
@@ -16,6 +15,8 @@ generateRuleTests({
     '<a href="/">link</a>',
     '<a href="/">link <strong>!!!</strong></a>',
     '<button><input type="hidden"></button>',
+    '<div tabindex=-1><button>Click me!</button></div>',
+    '<div tabindex="1"><button></button></div>',
     {
       config: {
         ignoredTags: ['button']
@@ -157,18 +158,6 @@ generateRuleTests({
         source: '<textarea></textarea>',
         line: 1,
         column: 8
-      }
-    },
-    {
-      template: '<div tabindex="1"><button></button></div>',
-
-      result: {
-        rule: 'nested-interactive',
-        message: 'Do not use <button> inside an element with the `tabindex` attribute',
-        moduleId: 'layout.hbs',
-        source: '<button></button>',
-        line: 1,
-        column: 18
       }
     },
     {


### PR DESCRIPTION
Fixes #51.