### PR TITLE
Handle <label> as an interactive element.

### DIFF
--- a/lib/helpers/is-interactive-element.js
+++ b/lib/helpers/is-interactive-element.js
@@ -9,6 +9,7 @@ var INTERACTIVE_TAG_NAMES = [
   'iframe',
   'input',
   'keygen',
+  'label',
   'select',
   'textarea'
 ];

--- a/lib/rules/lint-nested-interactive.js
+++ b/lib/rules/lint-nested-interactive.js
@@ -133,7 +133,18 @@ module.exports = function(addonContext) {
         if (!isInteractive) { return; }
         if (this.isInteractiveExcluded(node)) { return; }
 
-        if (this._parentInteractiveNode) {
+        if (this.hasLabelParentNode()) {
+          if (this._seenInteractiveChild) {
+            this.log({
+              message: 'Do not use multiple interactive elements inside a single `<label>`',
+              line: node.loc && node.loc.start.line,
+              column: node.loc && node.loc.start.column,
+              source: this.sourceForNode(this._parentInteractiveNode)
+            });
+          } else {
+            this._seenInteractiveChild = true;
+          }
+        } else if (this.hasParentNode()) {
           this.log({
             message: this.getLogMessage(node, this._parentInteractiveNode),
             line: node.loc && node.loc.start.line,
@@ -152,6 +163,7 @@ module.exports = function(addonContext) {
       exit: function(node) {
         if (this._parentInteractiveNode === node) {
           this._parentInteractiveNode = null;
+          this._seenInteractiveChild = false;
         }
       }
     };
@@ -160,6 +172,14 @@ module.exports = function(addonContext) {
       ElementNode: visitor,
       ComponentNode: visitor
     };
+  };
+
+  LogNestedInteractive.prototype.hasLabelParentNode = function() {
+    return this._parentInteractiveNode && this._parentInteractiveNode.tag === 'label';
+  };
+
+  LogNestedInteractive.prototype.hasParentNode = function() {
+    return this._parentInteractiveNode;
   };
 
   LogNestedInteractive.prototype.isCustomInteractiveElement = function(node) {

--- a/test/unit/is-interactive-element-test.js
+++ b/test/unit/is-interactive-element-test.js
@@ -41,7 +41,8 @@ describe('isInteractiveElement', function() {
     '<textarea></textarea>': '<textarea>',
     '<img usemap="#foo">': 'an <img> element with the `usemap` attribute',
     '<object usemap="#foo"></object>': 'an <object> element with the `usemap` attribute',
-    '<div tabindex=1></div>': 'an element with the `tabindex` attribute'
+    '<div tabindex=1></div>': 'an element with the `tabindex` attribute',
+    '<label></label>': '<label>'
   };
 
   nonInteractive.forEach(function(template) {

--- a/test/unit/plugins/lint-nested-interactive-test.js
+++ b/test/unit/plugins/lint-nested-interactive-test.js
@@ -17,6 +17,7 @@ generateRuleTests({
     '<button><input type="hidden"></button>',
     '<div tabindex=-1><button>Click me!</button></div>',
     '<div tabindex="1"><button></button></div>',
+    '<label><input></label>',
     {
       config: {
         ignoredTags: ['button']
@@ -209,6 +210,37 @@ generateRuleTests({
         source: '<my-special-input></my-special-input>',
         line: 1,
         column: 8
+      }
+    },
+
+    {
+      template: '<label><input><input></label>',
+
+      result: {
+        rule: 'nested-interactive',
+        message: 'Do not use multiple interactive elements inside a single `<label>`',
+        moduleId: 'layout.hbs',
+        source: '<label><input><input></label>',
+        line: 1,
+        column: 14
+      }
+    },
+
+    {
+      template: [
+        '<label for="foo">',
+        '  <div id="foo" tabindex=-1></div>',
+        '  <input>',
+        '</label>'
+      ].join('\n'),
+
+      result: {
+        rule: 'nested-interactive',
+        message: 'Do not use multiple interactive elements inside a single `<label>`',
+        moduleId: 'layout.hbs',
+        source: '<label for="foo">\n  <div id="foo" tabindex=-1></div>\n  <input>\n</label>',
+        line: 3,
+        column: 2
       }
     },
 


### PR DESCRIPTION
* Add `label` to the list of interactive element tag names.
* Specifically handle the various edge cases of having
  `<label><input></label>`.
* Prevent multiple interactive elements inside of an element.

Fixes #52.