### PR TITLE
Rule: img tags must have alt attributes

### DIFF
--- a/lib/helpers/ast-node-info.js
+++ b/lib/helpers/ast-node-info.js
@@ -41,6 +41,10 @@ function findAttribute(node, attributeName) {
   }
 }
 
+function isImgElement(node) {
+  return node.tag === 'img';
+}
+
 module.exports = {
   isConfigurationHtmlComment: isConfigurationHtmlComment,
   isNonConfigurationHtmlComment: isNonConfigurationHtmlComment,
@@ -49,5 +53,6 @@ module.exports = {
   isComponentNode: isComponentNode,
   isBlockStatement: isBlockStatement,
   hasAttribute: hasAttribute,
-  findAttribute: findAttribute
+  findAttribute: findAttribute,
+  isImgElement: isImgElement
 };

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -4,6 +4,7 @@ module.exports = {
   'bare-strings': require('./lint-bare-strings'),
   'block-indentation': require('./lint-block-indentation'),
   'html-comments': require('./lint-html-comments'),
+  'img-alt-attributes': require('./lint-img-alt-attributes'),
   'triple-curlies': require('./lint-triple-curlies'),
   'self-closing-void-elements': require('./lint-self-closing-void-elements'),
   'nested-interactive': require('./lint-nested-interactive'),

--- a/lib/rules/lint-img-alt-attributes.js
+++ b/lib/rules/lint-img-alt-attributes.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var AstNodeInfo = require('../helpers/ast-node-info');
+var buildPlugin = require('./base');
+
+module.exports = function(addonContext) {
+  var ImgAltAttributes = buildPlugin(addonContext, 'img-alt-attributes');
+
+  ImgAltAttributes.prototype.visitors = function() {
+    return {
+      ElementNode: function(node) {
+        if (AstNodeInfo.isImgElement(node) && !AstNodeInfo.findAttribute(node, 'alt')) {
+          this.log({
+            message: 'img tags must have an alt attribute',
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node)
+          });
+        }
+      }
+    };
+  };
+
+  return ImgAltAttributes;
+};

--- a/lib/rules/lint-img-alt-attributes.js
+++ b/lib/rules/lint-img-alt-attributes.js
@@ -9,7 +9,9 @@ module.exports = function(addonContext) {
   ImgAltAttributes.prototype.visitors = function() {
     return {
       ElementNode: function(node) {
-        if (AstNodeInfo.isImgElement(node) && !AstNodeInfo.findAttribute(node, 'alt')) {
+        var altAttribute = AstNodeInfo.findAttribute(node, 'alt');
+        var altPresent = altAttribute && altAttribute.value.chars.length;
+        if (AstNodeInfo.isImgElement(node) && !altPresent) {
           this.log({
             message: 'img tags must have an alt attribute',
             line: node.loc && node.loc.start.line,

--- a/test/unit/helpers/ast-node-info-test.js
+++ b/test/unit/helpers/ast-node-info-test.js
@@ -1,0 +1,13 @@
+var assert = require('power-assert');
+var parse = require('htmlbars/dist/cjs/htmlbars-syntax').parse;
+var AstNodeInfo = require('../../../lib/helpers/ast-node-info');
+
+describe('isImgElement', function() {
+  it('can detect an image tag', function() {
+    var tableAst = parse('<table></table>');
+    assert(AstNodeInfo.isImgElement(tableAst.body[0]) === false);
+
+    var imgAst = parse('<img />');
+    assert(AstNodeInfo.isImgElement(imgAst.body[0]) === true);
+  });
+});

--- a/test/unit/helpers/is-interactive-element-test.js
+++ b/test/unit/helpers/is-interactive-element-test.js
@@ -1,6 +1,6 @@
 var assert = require('power-assert');
 var parse = require('htmlbars/dist/cjs/htmlbars-syntax').parse;
-var isInteractiveElement = require('../../lib/helpers/is-interactive-element');
+var isInteractiveElement = require('../../../lib/helpers/is-interactive-element');
 
 describe('isInteractiveElement', function() {
   function testTemplate(template, expectedValue) {

--- a/test/unit/rules/lint-img-alt-attributes-test.js
+++ b/test/unit/rules/lint-img-alt-attributes-test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'img-alt-attributes',
+
+  config: true,
+
+  good: [
+    '<img alt="hullo">'
+  ],
+
+  bad: [
+    {
+      template: '<img>',
+
+      result: {
+        rule: 'img-alt-attributes',
+        message: 'img tags must have an alt attribute',
+        moduleId: 'layout.hbs',
+        source: '<img>',
+        line: 1,
+        column: 0
+      }
+    }
+  ]
+});

--- a/test/unit/rules/lint-img-alt-attributes-test.js
+++ b/test/unit/rules/lint-img-alt-attributes-test.js
@@ -8,7 +8,8 @@ generateRuleTests({
   config: true,
 
   good: [
-    '<img alt="hullo">'
+    '<img alt="hullo">',
+    '<img src="hello.jpg" alt="">'
   ],
 
   bad: [

--- a/test/unit/rules/lint-img-alt-attributes-test.js
+++ b/test/unit/rules/lint-img-alt-attributes-test.js
@@ -8,8 +8,7 @@ generateRuleTests({
   config: true,
 
   good: [
-    '<img alt="hullo">',
-    '<img src="hello.jpg" alt="">'
+    '<img alt="hullo">'
   ],
 
   bad: [
@@ -21,6 +20,30 @@ generateRuleTests({
         message: 'img tags must have an alt attribute',
         moduleId: 'layout.hbs',
         source: '<img>',
+        line: 1,
+        column: 0
+      }
+    },
+    {
+      template: '<img alt>',
+
+      result: {
+        rule: 'img-alt-attributes',
+        message: 'img tags must have an alt attribute',
+        moduleId: 'layout.hbs',
+        source: '<img alt>',
+        line: 1,
+        column: 0
+      }
+    },
+    {
+      template: '<img alt="">',
+
+      result: {
+        rule: 'img-alt-attributes',
+        message: 'img tags must have an alt attribute',
+        moduleId: 'layout.hbs',
+        source: '<img alt="">',
         line: 1,
         column: 0
       }


### PR DESCRIPTION
Requires `img` tags to have an `alt` attribute defined. See #45 for more information.

Fixes #45