### PR TITLE
Add `lint-invalid-interactive` rule.

### DIFF
--- a/lib/helpers/is-interactive-element.js
+++ b/lib/helpers/is-interactive-element.js
@@ -14,6 +14,36 @@ var INTERACTIVE_TAG_NAMES = [
   'textarea'
 ];
 
+// Spec: https://www.w3.org/TR/wai-aria/complete#widget_roles
+
+var ARIA_WIDGET_ROLES = [
+  'alert',
+  'alertdialog',
+  'button',
+  'checkbox',
+  'dialog',
+  'gridcell',
+  'link',
+  'log',
+  'marquee',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'progressbar',
+  'radio',
+  'scrollbar',
+  'slider',
+  'spinbutton',
+  'status',
+  'tab',
+  'tabpanel',
+  'textbox',
+  'timer',
+  'tooltip',
+  'treeitem'
+];
+
 function isHyperLink(node) {
   return node.tag === 'a' && ast.hasAttribute(node, 'href');
 }
@@ -24,6 +54,15 @@ function isHiddenInput(node) {
   var type = ast.findAttribute(node, 'type');
   if (type && type.value && type.value.chars === 'hidden') {
     return true;
+  }
+
+  return false;
+}
+
+function getInteractiveAriaRole(node) {
+  var role = ast.findAttribute(node, 'role');
+  if (role && role.value && ARIA_WIDGET_ROLES.indexOf(role.value.chars) > -1) {
+    return 'role="' + role.value.chars + '"';
   }
 
   return false;
@@ -47,6 +86,11 @@ function reason(node) {
 
   if (INTERACTIVE_TAG_NAMES.indexOf(node.tag) > -1) {
     return '<' + node.tag + '>';
+  }
+
+  var role;
+  if ((role = getInteractiveAriaRole(node))) {
+    return 'an element with `' + role + '`';
   }
 
   if (isHyperLink(node)) {

--- a/lib/helpers/parse-interactive-element-config.js
+++ b/lib/helpers/parse-interactive-element-config.js
@@ -1,0 +1,56 @@
+'use strict';
+
+function configValid(config) {
+  for (var key in config) {
+    var value = config[key];
+
+    switch (key) {
+    case 'ignoredTags':
+    case 'additionalInteractiveTags':
+      if (!Array.isArray(value)) {
+        return false;
+      }
+      break;
+    case 'ignoreTabindex':
+    case 'ignoreUsemapAttribute':
+      if (typeof value !== 'boolean') {
+        return false;
+      }
+      break;
+    default:
+      return false;
+    }
+  }
+
+  return true;
+}
+
+module.exports = function(ruleName, config) {
+  var configType = typeof config;
+
+  var errorMessage = [
+    'The ' + ruleName + ' rule accepts one of the following values.',
+    '  * boolean - `true` to enable / `false` to disable',
+    '  * object - Containing the following values:',
+    '    * `ignoredTags` - An array of element tag names that should be whitelisted. Default to `[]`.',
+    '    * `ignoreTabindex` - When `true` tabindex will be ignored. Defaults to `false`.',
+    '    * `ignoreUsemapAttribute` - When `true` ignores the `usemap` attribute on `img` and `object` elements. Defaults `false`.',
+    '    * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.',
+    'You specified `' + JSON.stringify(config) + '`'
+  ].join('\n');
+
+  switch (configType) {
+  case 'boolean':
+    return config;
+  case 'object':
+    if (configValid(config)) {
+      return config;
+    } else {
+      throw new Error(errorMessage);
+    }
+  case 'undefined':
+    return false;
+  default:
+    throw new Error(errorMessage);
+  }
+};

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -8,5 +8,6 @@ module.exports = {
   'triple-curlies': require('./lint-triple-curlies'),
   'self-closing-void-elements': require('./lint-self-closing-void-elements'),
   'nested-interactive': require('./lint-nested-interactive'),
-  'deprecated-each-syntax': require('./deprecations/lint-deprecated-each-syntax')
+  'deprecated-each-syntax': require('./deprecations/lint-deprecated-each-syntax'),
+  'invalid-interactive': require('./lint-invalid-interactive')
 };

--- a/lib/rules/lint-invalid-interactive.js
+++ b/lib/rules/lint-invalid-interactive.js
@@ -27,13 +27,13 @@ module.exports = function(addonContext) {
       }
     };
 
-
     return {
       ElementModifierStatement: function(node) {
         var isInteractive = isInteractiveElement(this._element);
         var modifierName = node.path.original;
+        var hasRole = AstNodeInfo.hasAttribute(this._element, 'role');
 
-        if (modifierName === 'action' && !isInteractive) {
+        if (modifierName === 'action' && !isInteractive && !hasRole) {
           this.log({
             message: 'Interaction added to non-interactive element',
             line: node.loc && node.loc.start.line,
@@ -42,6 +42,7 @@ module.exports = function(addonContext) {
           });
         }
       },
+
       ElementNode: visitor,
       ComponentNode: visitor
     };

--- a/lib/rules/lint-invalid-interactive.js
+++ b/lib/rules/lint-invalid-interactive.js
@@ -3,7 +3,6 @@
 var buildPlugin = require('./base');
 var isInteractiveElement = require('../helpers/is-interactive-element');
 var parseConfig = require('../helpers/parse-interactive-element-config');
-var AstNodeInfo = require('../helpers/ast-node-info');
 
 module.exports = function(addonContext) {
   var InvalidInteractive = buildPlugin(addonContext, 'invalid-interactive');
@@ -31,9 +30,8 @@ module.exports = function(addonContext) {
       ElementModifierStatement: function(node) {
         var isInteractive = isInteractiveElement(this._element);
         var modifierName = node.path.original;
-        var hasRole = AstNodeInfo.hasAttribute(this._element, 'role');
 
-        if (modifierName === 'action' && !isInteractive && !hasRole) {
+        if (modifierName === 'action' && !isInteractive) {
           this.log({
             message: 'Interaction added to non-interactive element',
             line: node.loc && node.loc.start.line,

--- a/lib/rules/lint-invalid-interactive.js
+++ b/lib/rules/lint-invalid-interactive.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var buildPlugin = require('./base');
+var isInteractiveElement = require('../helpers/is-interactive-element');
+
+module.exports = function(addonContext) {
+  var InvalidInteractive = buildPlugin(addonContext, 'invalid-interactive');
+
+  InvalidInteractive.prototype.visitors = function() {
+    this._element = null;
+
+    var visitor = {
+      enter: function(node) {
+        this._element = node;
+      },
+
+      exit: function(node) {
+        if (this._element === node) {
+          this._element = null;
+        }
+      }
+    };
+
+
+    return {
+      ElementModifierStatement: function(node) {
+        var isInteractive = isInteractiveElement(this._element);
+        var modifierName = node.path.original;
+
+        if (modifierName === 'action' && !isInteractive) {
+          this.log({
+            message: 'Interaction added to non-interactive element',
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(this._element)
+          });
+        }
+      },
+      ElementNode: visitor,
+      ComponentNode: visitor
+    };
+  };
+
+  return InvalidInteractive;
+};

--- a/lib/rules/lint-invalid-interactive.js
+++ b/lib/rules/lint-invalid-interactive.js
@@ -2,9 +2,15 @@
 
 var buildPlugin = require('./base');
 var isInteractiveElement = require('../helpers/is-interactive-element');
+var parseConfig = require('../helpers/parse-interactive-element-config');
+var AstNodeInfo = require('../helpers/ast-node-info');
 
 module.exports = function(addonContext) {
   var InvalidInteractive = buildPlugin(addonContext, 'invalid-interactive');
+
+  InvalidInteractive.prototype.parseConfig = function(config) {
+    return parseConfig(this.ruleName, config);
+  };
 
   InvalidInteractive.prototype.visitors = function() {
     this._element = null;

--- a/lib/rules/lint-nested-interactive.js
+++ b/lib/rules/lint-nested-interactive.js
@@ -18,33 +18,9 @@
 
 var buildPlugin = require('./base');
 var isInteractiveElement = require('../helpers/is-interactive-element');
+var parseConfig = require('../helpers/parse-interactive-element-config');
 
 var ARRAY_DEPRECATION_MESSAGE = 'Specifying an array as the configurate for the `nested-interactive` rule is deprecated and will be removed in future versions.  Please update `.template-lintrc.js` to use the newer object format.';
-
-function configValid(config) {
-  for (var key in config) {
-    var value = config[key];
-
-    switch (key) {
-    case 'ignoredTags':
-    case 'additionalInteractiveTags':
-      if (!Array.isArray(value)) {
-        return false;
-      }
-      break;
-    case 'ignoreTabindex':
-    case 'ignoreUsemapAttribute':
-      if (typeof value !== 'boolean') {
-        return false;
-      }
-      break;
-    default:
-      return false;
-    }
-  }
-
-  return true;
-}
 
 function convertConfigArrayToObject(config) {
   var base = {
@@ -75,40 +51,11 @@ module.exports = function(addonContext) {
   var LogNestedInteractive = buildPlugin(addonContext, 'nested-interactive');
 
   LogNestedInteractive.prototype.parseConfig = function(config) {
-    var configType = typeof config;
-
-    var errorMessage = [
-      'The nested-interactive rule accepts one of the following values.',
-      '  * boolean - `true` to enable / `false` to disable',
-      '  * object - Containing the following values:',
-      '    * `ignoredTags` - An array of element tag names that should be whitelisted. Default to `[]`.',
-      '    * `ignoreTabindex` - When `true` tabindex will be ignored. Defaults to `false`.',
-      '    * `ignoreUsemapAttribute` - When `true` ignores the `usemap` attribute on `img` and `object` elements. Defaults `false`.',
-      '    * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.',
-      'You specified `' + JSON.stringify(config) + '`'
-    ].join('\n');
-
-    switch (configType) {
-    case 'boolean':
-      return config;
-    case 'object':
-      if (configValid(config)) {
-        return config;
-      } else if (Array.isArray(config)) {
-        this.log({
-          message: ARRAY_DEPRECATION_MESSAGE,
-          source: JSON.stringify(config),
-          severity: 1
-        });
-        return convertConfigArrayToObject(config);
-      } else {
-        throw new Error(errorMessage);
-      }
-    case 'undefined':
-      return false;
-    default:
-      throw new Error(errorMessage);
+    if (Array.isArray(config)) {
+      return convertConfigArrayToObject(config);
     }
+
+    return parseConfig(this.ruleName, config);
   };
 
   LogNestedInteractive.prototype.getConfigWhiteList = function() {

--- a/lib/rules/lint-nested-interactive.js
+++ b/lib/rules/lint-nested-interactive.js
@@ -52,6 +52,12 @@ module.exports = function(addonContext) {
 
   LogNestedInteractive.prototype.parseConfig = function(config) {
     if (Array.isArray(config)) {
+      this.log({
+        message: ARRAY_DEPRECATION_MESSAGE,
+        source: JSON.stringify(config),
+        severity: 1
+      });
+
       return convertConfigArrayToObject(config);
     }
 

--- a/test/unit/helpers/is-interactive-element-test.js
+++ b/test/unit/helpers/is-interactive-element-test.js
@@ -42,7 +42,9 @@ describe('isInteractiveElement', function() {
     '<img usemap="#foo">': 'an <img> element with the `usemap` attribute',
     '<object usemap="#foo"></object>': 'an <object> element with the `usemap` attribute',
     '<div tabindex=1></div>': 'an element with the `tabindex` attribute',
-    '<label></label>': '<label>'
+    '<label></label>': '<label>',
+    '<div role="button"></div>': 'an element with `role="button"`',
+    '<div role="dialog"></div>': 'an element with `role="dialog"`'
   };
 
   nonInteractive.forEach(function(template) {

--- a/test/unit/rules/lint-invalid-interactive-test.js
+++ b/test/unit/rules/lint-invalid-interactive-test.js
@@ -5,8 +5,13 @@ var generateRuleTests = require('../../helpers/rule-test-harness');
 generateRuleTests({
   name: 'invalid-interactive',
 
-  good: [
+  config: true,
 
+  focus: true,
+
+  good: [
+    '<button {{action "foo"}}></button>',
+    '<div role="button" {{action "foo"}}></div>'
   ],
 
   bad: [
@@ -14,10 +19,10 @@ generateRuleTests({
       template: '<div {{action "foo"}}></div>',
 
       result: {
-        message: 'Interaction added to non-interactive element.',
+        message: 'Interaction added to non-interactive element',
         line: 1,
-        column: 0,
-        source: '\n howdy'
+        column: 5,
+        source: '<div {{action \"foo\"}}></div>'
       }
     }
   ]

--- a/test/unit/rules/lint-invalid-interactive-test.js
+++ b/test/unit/rules/lint-invalid-interactive-test.js
@@ -7,8 +7,6 @@ generateRuleTests({
 
   config: true,
 
-  focus: true,
-
   good: [
     '<button {{action "foo"}}></button>',
     '<div role="button" {{action "foo"}}></div>'

--- a/test/unit/rules/lint-invalid-interactive-test.js
+++ b/test/unit/rules/lint-invalid-interactive-test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'invalid-interactive',
+
+  good: [
+
+  ],
+
+  bad: [
+    {
+      template: '<div {{action "foo"}}></div>',
+
+      result: {
+        message: 'Interaction added to non-interactive element.',
+        line: 1,
+        column: 0,
+        source: '\n howdy'
+      }
+    }
+  ]
+});


### PR DESCRIPTION
This rule prevents usage of `{{action` on elements that are not considered interactive elements.

Closes #41.