### PR TITLE
Allow `<img aria-hidden="true">` in img-alt-attributes rule.

### DIFF
--- a/lib/rules/lint-img-alt-attributes.js
+++ b/lib/rules/lint-img-alt-attributes.js
@@ -24,9 +24,13 @@ module.exports = function(addonContext) {
   ImgAltAttributes.prototype.visitors = function() {
     return {
       ElementNode: function(node) {
-        var altAttribute = AstNodeInfo.findAttribute(node, 'alt');
-        var altPresent = altAttribute && altAttribute.value.chars.length;
-        if (AstNodeInfo.isImgElement(node) && !altPresent) {
+        var isImg = AstNodeInfo.isImgElement(node);
+        if (!isImg) { return; }
+
+        var ariaHidden = AstNodeInfo.hasAttribute(node, 'aria-hidden');
+        var altPresent = isAltPresent(node);
+
+        if (!ariaHidden && !altPresent) {
           this.log({
             message: 'img tags must have an alt attribute',
             line: node.loc && node.loc.start.line,
@@ -40,3 +44,18 @@ module.exports = function(addonContext) {
 
   return ImgAltAttributes;
 };
+
+
+function isAltPresent(node) {
+  var altAttribute = AstNodeInfo.findAttribute(node, 'alt');
+
+  if (!altAttribute) { return false; }
+
+  switch (altAttribute.value.type) {
+  case 'TextNode':
+    return altAttribute.value.chars.length > 0;
+  case 'ConcatStatement':
+  case 'MustacheStatement':
+    return true;
+  }
+}

--- a/test/unit/rules/lint-img-alt-attributes-test.js
+++ b/test/unit/rules/lint-img-alt-attributes-test.js
@@ -8,7 +8,10 @@ generateRuleTests({
   config: true,
 
   good: [
-    '<img alt="hullo">'
+    '<img alt="hullo">',
+    '<img alt={{foo}}>',
+    '<img alt="blah {{derp}}">',
+    '<img aria-hidden="true">'
   ],
 
   bad: [


### PR DESCRIPTION
Fixes #72.