### PR TITLE
Allow child elements of non-interactive elements

### DIFF
--- a/lib/rules/lint-invalid-interactive.js
+++ b/lib/rules/lint-invalid-interactive.js
@@ -16,9 +16,7 @@ module.exports = function(addonContext) {
 
     var visitor = {
       enter: function(node) {
-        if (!isInteractiveElement(node)) {
-          this._element = node;
-        }
+        this._element = !isInteractiveElement(node) ? node : null;
       },
 
       exit: function(node) {

--- a/test/unit/rules/lint-invalid-interactive-test.js
+++ b/test/unit/rules/lint-invalid-interactive-test.js
@@ -9,7 +9,8 @@ generateRuleTests({
 
   good: [
     '<button {{action "foo"}}></button>',
-    '<div role="button" {{action "foo"}}></div>'
+    '<div role="button" {{action "foo"}}></div>',
+    '<li><button {{action "foo"}}></button></li>'
   ],
 
   bad: [


### PR DESCRIPTION
The invalid interactive rule only keeps track of entering and exiting non-interactive elements. This means that the rule will be triggered on a valid interactive element that has any non-interactive parents.

This PR resets the state of the current element for every `ElementNode` that is visited.

Fixes #80.