### PR TITLE
Don't check end block indentation of empty ElementNodes

### DIFF
--- a/lib/helpers/ast-node-info.js
+++ b/lib/helpers/ast-node-info.js
@@ -12,12 +12,20 @@ function isTextNode(node) {
   return node.type === 'TextNode';
 }
 
+function isCommentStatement(node) {
+  return node.type === 'CommentStatement';
+}
+
 function isElementNode(node) {
   return node && node.type === 'ElementNode';
 }
 
 function isComponentNode(node) {
   return node && node.type === 'ComponentNode';
+}
+
+function isMustacheStatement(node) {
+  return node.type === 'MustacheStatement';
 }
 
 function isBlockStatement(node) {
@@ -45,14 +53,35 @@ function isImgElement(node) {
   return node.tag === 'img';
 }
 
+function childrenFor(node) {
+  if (node.type === 'Program') {
+    return node.body;
+  }
+  if (node.type === 'BlockStatement') {
+    return node.program.body;
+  }
+  if (node.type === 'ElementNode') {
+    return node.children;
+  }
+}
+
+function hasChildren(node) {
+  var children = childrenFor(node);
+  return children && children.length;
+}
+
 module.exports = {
-  isConfigurationHtmlComment: isConfigurationHtmlComment,
-  isNonConfigurationHtmlComment: isNonConfigurationHtmlComment,
-  isTextNode: isTextNode,
-  isElementNode: isElementNode,
-  isComponentNode: isComponentNode,
-  isBlockStatement: isBlockStatement,
-  hasAttribute: hasAttribute,
+  childrenFor: childrenFor,
   findAttribute: findAttribute,
-  isImgElement: isImgElement
+  hasAttribute: hasAttribute,
+  hasChildren: hasChildren,
+  isBlockStatement: isBlockStatement,
+  isCommentStatement: isCommentStatement,
+  isComponentNode: isComponentNode,
+  isConfigurationHtmlComment: isConfigurationHtmlComment,
+  isElementNode: isElementNode,
+  isImgElement: isImgElement,
+  isMustacheStatement: isMustacheStatement,
+  isNonConfigurationHtmlComment: isNonConfigurationHtmlComment,
+  isTextNode: isTextNode
 };

--- a/lib/helpers/ast-node-info.js
+++ b/lib/helpers/ast-node-info.js
@@ -67,7 +67,7 @@ function childrenFor(node) {
 
 function hasChildren(node) {
   var children = childrenFor(node);
-  return children && children.length;
+  return !!(children && children.length);
 }
 
 module.exports = {

--- a/lib/rules/lint-block-indentation.js
+++ b/lib/rules/lint-block-indentation.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var AstNodeInfo = require('../helpers/ast-node-info');
+
 /*
  Forces valid indentation for blocks and their children.
 
@@ -66,26 +68,6 @@ var VOID_TAGS = { area: true,
                   track: true,
                   wbr: true };
 
-function childrenFor(node) {
-  if (node.type === 'Program') {
-    return node.body;
-  }
-  if (node.type === 'BlockStatement') {
-    return node.program.body;
-  }
-  if (node.type === 'ElementNode') {
-    return node.children;
-  }
-}
-
-function isTextNode(node) {
-  return node.type === 'TextNode';
-}
-
-function isCommentStatement(node) {
-  return node.type === 'CommentStatement';
-}
-
 module.exports = function(addonContext) {
   var BlockIndentation = buildPlugin(addonContext, 'block-indentation');
 
@@ -140,7 +122,7 @@ module.exports = function(addonContext) {
       return;
     }
 
-    var isElementNode = node.type === 'ElementNode';
+    var isElementNode = AstNodeInfo.isElementNode(node);
     var displayName = isElementNode ? node.tag : node.path.original;
     var display = isElementNode ? '</' + displayName + '>' : '{{/' + displayName + '}}';
     var startColumn = node.loc.start.column;
@@ -168,9 +150,9 @@ module.exports = function(addonContext) {
   };
 
   BlockIndentation.prototype.validateBlockChildren = function(node) {
-    var children = childrenFor(node);
+    var children = AstNodeInfo.childrenFor(node);
 
-    if (!children || !children.length) {
+    if (!AstNodeInfo.hasChildren(node)) {
       return;
     }
 
@@ -192,7 +174,7 @@ module.exports = function(addonContext) {
       var hasLeadingContent = false;
       for (var j = i - 1; j >= 0; j--) {
         var sibling = children[j];
-        if (sibling.loc && !isTextNode(sibling)) {
+        if (sibling.loc && !AstNodeInfo.isTextNode(sibling)) {
           // Found an element or statement. If it's on this line, then we
           // have leading content, so set the flag and break. If it's not
           // on this line, then we've scanned back to a previous line, so
@@ -225,7 +207,7 @@ module.exports = function(addonContext) {
 
       var childStartColumn;
       // sanitize text node starting column info
-      if (isTextNode(child)) {
+      if (AstNodeInfo.isTextNode(child)) {
         // TextNode's include leading newlines, but those newlines do
         // not get used in calculating indentation
         var withoutLeadingNewLines = child.chars.replace(/^(\r\n|\n)*/, '');
@@ -246,18 +228,18 @@ module.exports = function(addonContext) {
       }
 
       if (expectedStartColumn !== childStartColumn) {
-        var isElementNode = child.type === 'ElementNode';
+        var isElementNode = AstNodeInfo.isElementNode(child);
         var display;
 
         if (isElementNode) {
           display = '<' + child.tag + '>';
-        } else if (child.type === 'BlockStatement'){
+        } else if (AstNodeInfo.isBlockStatement(child)){
           display = '{{#' + child.path.original + '}}';
-        } else if (child.type === 'MustacheStatement') {
+        } else if (AstNodeInfo.isMustacheStatement(child)) {
           display = '{{' + child.path.original + '}}';
-        } else if (isTextNode(child)) {
+        } else if (AstNodeInfo.isTextNode(child)) {
           display = child.chars;
-        } else if (isCommentStatement(child)) {
+        } else if (AstNodeInfo.isCommentStatement(child)) {
           display = '<!--' + child.value + '-->';
         } else {
           display = child.path.original;
@@ -279,7 +261,7 @@ module.exports = function(addonContext) {
   };
 
   BlockIndentation.prototype.validateBlockElse = function(node) {
-    if (node.type !== 'BlockStatement' || !node.inverse) {
+    if (!AstNodeInfo.isBlockStatement(node) || !node.inverse) {
       return;
     }
 
@@ -314,7 +296,7 @@ module.exports = function(addonContext) {
     var firstItem = inverse && inverse.body[0];
 
     // handle `{{else if foo}}`
-    if (inverse && firstItem && firstItem.type === 'BlockStatement') {
+    if (inverse && firstItem && AstNodeInfo.isBlockStatement(firstItem)) {
       return inverse.loc.start.line === firstItem.loc.start.line &&
         inverse.loc.start.column === firstItem.loc.start.column;
     }
@@ -344,9 +326,8 @@ module.exports = function(addonContext) {
     }
 
     // do not validate nodes without children (whitespace will count as TextNodes)
-    if (node.type === 'ElementNode') {
-      var children = childrenFor(node);
-      return children && children.length;
+    if (AstNodeInfo.isElementNode(node)) {
+      return AstNodeInfo.hasChildren(node);
     }
 
     var source = this.sourceForNode(node);
@@ -357,7 +338,7 @@ module.exports = function(addonContext) {
   };
 
   BlockIndentation.prototype.endingControlCharCount = function(node) {
-    if (node.type === 'ElementNode') {
+    if (AstNodeInfo.isElementNode(node)) {
       // </>
       return 3;
     }

--- a/lib/rules/lint-block-indentation.js
+++ b/lib/rules/lint-block-indentation.js
@@ -343,8 +343,10 @@ module.exports = function(addonContext) {
       return false;
     }
 
+    // do not validate nodes without children (whitespace will count as TextNodes)
     if (node.type === 'ElementNode') {
-      return true;
+      var children = childrenFor(node);
+      return children && children.length;
     }
 
     var source = this.sourceForNode(node);

--- a/test/unit/helpers/ast-node-info-test.js
+++ b/test/unit/helpers/ast-node-info-test.js
@@ -11,3 +11,25 @@ describe('isImgElement', function() {
     assert(AstNodeInfo.isImgElement(imgAst.body[0]) === true);
   });
 });
+
+describe('hasChildren', function() {
+  it('functions for empty input', function() {
+    assert(AstNodeInfo.hasChildren(parse('')) === false);
+  });
+
+  it('functions for empty elements', function() {
+    var ast = parse('<div></div>');
+    assert(AstNodeInfo.hasChildren(ast.body[0]) === false);
+    assert(AstNodeInfo.hasChildren(ast) === true);
+  });
+
+  it('detects text', function() {
+    var ast = parse('<div>hello</div>');
+    assert(AstNodeInfo.hasChildren(ast.body[0]) === true);
+  });
+
+  it('detects whitespace', function() {
+    var ast = parse('<div> </div>');
+    assert(AstNodeInfo.hasChildren(ast.body[0]) === true);
+  });
+});

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -124,6 +124,10 @@ generateRuleTests({
       '  <div></div>',
       '{{~/if~}}'
     ].join('\n'),
+    [
+      '<div class="multi"',
+      '     id="lines"></div>'
+    ].join('\n'),
     {
       config: 4,
 
@@ -166,7 +170,18 @@ generateRuleTests({
         column: 17
       }
     },
+    {
+      template: '<div>\n  </div>',
 
+      result: {
+        rule: 'block-indentation',
+        message: 'Incorrect indentation for `div` beginning at L1:C0. Expected `</div>` ending at L2:C8 to be at an indentation of 0 but was found at 2.',
+        moduleId: 'layout.hbs',
+        source: '<div>\n  </div>',
+        line: 2,
+        column: 8
+      }
+    },
     {
       template: '<div>\n  <p>Stuff goes here</p></div>',
 


### PR DESCRIPTION
The block-indentation rule is raised if the start tag spans multiple lines - even if the start tag is empty. E.g.

```
<div id="multi"
       class="line"></div>
```

This PR skips checking the indentation of an end tag if the element does not contain any children. Note that whitespace will generate a TextNode child if it exists.

Fixes #63 which is a duplicate of #57.