### PR TITLE
Remove some roles from interactive roles listing.

### DIFF
--- a/lib/helpers/is-interactive-element.js
+++ b/lib/helpers/is-interactive-element.js
@@ -17,29 +17,20 @@ var INTERACTIVE_TAG_NAMES = [
 // Spec: https://www.w3.org/TR/wai-aria/complete#widget_roles
 
 var ARIA_WIDGET_ROLES = [
-  'alert',
-  'alertdialog',
   'button',
   'checkbox',
-  'dialog',
-  'gridcell',
   'link',
-  'log',
-  'marquee',
   'menuitem',
   'menuitemcheckbox',
   'menuitemradio',
   'option',
-  'progressbar',
   'radio',
   'scrollbar',
   'slider',
   'spinbutton',
-  'status',
   'tab',
   'tabpanel',
   'textbox',
-  'timer',
   'tooltip',
   'treeitem'
 ];

--- a/test/unit/helpers/is-interactive-element-test.js
+++ b/test/unit/helpers/is-interactive-element-test.js
@@ -44,7 +44,7 @@ describe('isInteractiveElement', function() {
     '<div tabindex=1></div>': 'an element with the `tabindex` attribute',
     '<label></label>': '<label>',
     '<div role="button"></div>': 'an element with `role="button"`',
-    '<div role="dialog"></div>': 'an element with `role="dialog"`'
+    '<div role="textbox"></div>': 'an element with `role="textbox"`'
   };
 
   nonInteractive.forEach(function(template) {


### PR DESCRIPTION
Even those these are listed as "widgets" in the list [here](https://www.w3.org/TR/wai-aria/complete#widget_roles) their [descriptions](https://www.w3.org/TR/wai-aria/complete#role_definitions)  do not discuss interactivity, and they do not extend from an interactive superclass role.

It is possible that some of these will need to be brought back with more nuance (i.e. they may be considered interactive if other attributes are also present).

Fixes #83.