### PR TITLE
Add failing test for good use of `else if` with whitespace control

### DIFF
--- a/lib/rules/lint-link-rel-noopener.js
+++ b/lib/rules/lint-link-rel-noopener.js
@@ -65,7 +65,7 @@ function hasRelNoopener(node) {
 
   switch (relAttribute.value.type) {
   case 'TextNode':
-    return relAttribute.value.chars.indexOf('noopener') !== -1;
+    return /noopener|noreferrer/.test(relAttribute.value.chars);
   default:
     return false;
   }

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -125,6 +125,13 @@ generateRuleTests({
       '{{~/if~}}'
     ].join('\n'),
     [
+      '{{#if foo}}',
+      '  <div></div>',
+      '{{else if bar~}}',
+      '  <div></div>',
+      '{{/if}}'
+    ].join('\n'),
+    [
       '<div class="multi"',
       '     id="lines"></div>'
     ].join('\n'),

--- a/test/unit/rules/lint-link-rel-noopener-test.js
+++ b/test/unit/rules/lint-link-rel-noopener-test.js
@@ -11,7 +11,8 @@ generateRuleTests({
     '<a href="/some/where"></a>',
     '<a href="/some/where" target="_self"></a>',
     '<a href="/some/where" target="_blank" rel="noopener"></a>',
-    '<a href="/some/where" target="_blank" rel="noopener noreferrer"></a>'
+    '<a href="/some/where" target="_blank" rel="noopener noreferrer"></a>',
+    '<a href="/some/where" target="_blank" rel="noreferrer"></a>'
   ],
 
   bad: [


### PR DESCRIPTION
[Related issue #91](https://github.com/rwjblue/ember-template-lint/issues/91)
