### PR TITLE
Do not validate if source doesn't match node

### DIFF
--- a/lib/rules/lint-block-indentation.js
+++ b/lib/rules/lint-block-indentation.js
@@ -51,6 +51,7 @@ var AstNodeInfo = require('../helpers/ast-node-info');
  */
 
 var buildPlugin = require('./base');
+var VALID_FOLLOWING_CHARS = [' ', '>', '}', '~'];
 var VOID_TAGS = { area: true,
                   base: true,
                   br: true,
@@ -333,6 +334,12 @@ module.exports = function(addonContext) {
     var source = this.sourceForNode(node);
     var endingToken = '/' + node.path.original;
     var indexOfEnding = source.lastIndexOf(endingToken);
+
+    // Do not validate if source doesn't match node (if vs iframe)
+    var charAfterEnding = source[indexOfEnding + endingToken.length];
+    if (indexOfEnding !== -1 && VALID_FOLLOWING_CHARS.indexOf(charAfterEnding) === -1) {
+      return false;
+    } 
 
     return indexOfEnding !== -1;
   };

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -18,6 +18,13 @@ generateRuleTests({
       '  Good Morning',
       '{{{{/if}}}}'
     ].join('\n'),
+    [
+      '{{#if isDoc}}',
+      '  Download',
+      '{{else if isIframe}}',
+      '  <iframe src="some_url"></iframe>',
+      '{{/if}}'
+    ].join('\n'),
     '\n  {{#each cats as |dog|}}\n  {{/each}}',
     '<div><p>Stuff</p></div>',
     '<div>\n  <p>Stuff Here</p>\n</div>',


### PR DESCRIPTION
Currently is possible for nodes to be matched as closing parent nodes that are of different type.
`</iframe>` should not be considered closing for `</if>` or `{{/if}}`.
