### PR TITLE
Implement `link-rel-noopener` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,30 @@ The following values are valid configuration:
 
   * boolean -- `true` for enabled / `false` for disabled
 
+#### link-rel-noopener
+
+When you want to link in your app to some external page it is very common to use `<a href="url" target="_blank"></a>`
+to make the browser open this link in a new tab.
+However, this practice has performance problems (see [https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/](https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/))
+and also opens a door to some security attacks because the opened page can redirect the opener app to
+somewhere to a malicious clone to perform phishing on your users.
+
+To avoid those two problems, this rule forbids the following:
+
+```hbs
+<a href="https://i.seem.secure.com" target="_blank">I'm a bait</a>
+```
+
+Instead, you should write the template as:
+
+```hbs
+<a href="https://i.seem.secure.com" target="_blank" rel="noopener">I'm a bait</a>
+```
+
+The following values are valid configuration:
+
+  * boolean -- `true` for enabled / `false` for disabled
+
 #### invalid-interactive
 
 Adding interactivity to an element that is not naturally interactive content leads to a very poor experience for

--- a/lib/helpers/ast-node-info.js
+++ b/lib/helpers/ast-node-info.js
@@ -53,6 +53,10 @@ function isImgElement(node) {
   return node.tag === 'img';
 }
 
+function isLinkElement(node) {
+  return node.tag === 'a';
+}
+
 function childrenFor(node) {
   if (node.type === 'Program') {
     return node.body;
@@ -81,6 +85,7 @@ module.exports = {
   isConfigurationHtmlComment: isConfigurationHtmlComment,
   isElementNode: isElementNode,
   isImgElement: isImgElement,
+  isLinkElement: isLinkElement,
   isMustacheStatement: isMustacheStatement,
   isNonConfigurationHtmlComment: isNonConfigurationHtmlComment,
   isTextNode: isTextNode

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -5,6 +5,7 @@ module.exports = {
   'block-indentation': require('./lint-block-indentation'),
   'html-comments': require('./lint-html-comments'),
   'img-alt-attributes': require('./lint-img-alt-attributes'),
+  'link-rel-noopener': require('./lint-link-rel-noopener'),
   'triple-curlies': require('./lint-triple-curlies'),
   'self-closing-void-elements': require('./lint-self-closing-void-elements'),
   'nested-interactive': require('./lint-nested-interactive'),

--- a/lib/rules/lint-link-rel-noopener.js
+++ b/lib/rules/lint-link-rel-noopener.js
@@ -1,0 +1,72 @@
+'use strict';
+
+var AstNodeInfo = require('../helpers/ast-node-info');
+var buildPlugin = require('./base');
+
+/**
+ Disallow usage of `<a taget="_blank">` without an `rel="noopener"` attribute.
+
+ Good:
+
+ ```
+ <a href="/some/where" target="_blank" rel="noopener"></a>
+ ```
+
+ Bad:
+
+ ```
+ <a href="/some/where" target="_blank"></a>
+ ```
+ */
+module.exports = function(addonContext) {
+  var LinkRelNoopener = buildPlugin(addonContext, 'link-rel-noopener');
+
+  LinkRelNoopener.prototype.visitors = function() {
+    return {
+      ElementNode: function(node) {
+        var isLink = AstNodeInfo.isLinkElement(node);
+        if (!isLink) { return; }
+
+        var targetBlank = hasTargetBlank(node);
+        if (!targetBlank) { return; }
+
+        var relNoopener = hasRelNoopener(node);
+        if (relNoopener) { return; }
+
+        this.log({
+          message: 'links with target="_blank" must have rel="noopener"',
+          line: node.loc && node.loc.start.line,
+          column: node.loc && node.loc.start.column,
+          source: this.sourceForNode(node)
+        });
+      }
+    };
+  };
+
+  return LinkRelNoopener;
+};
+
+
+function hasTargetBlank(node) {
+  var targetAttribute = AstNodeInfo.findAttribute(node, 'target');
+  if (!targetAttribute) { return false; }
+
+  switch (targetAttribute.value.type) {
+  case 'TextNode':
+    return targetAttribute.value.chars === '_blank';
+  default:
+    return false;
+  }
+}
+
+function hasRelNoopener(node) {
+  var relAttribute = AstNodeInfo.findAttribute(node, 'rel');
+  if (!relAttribute) { return false; }
+
+  switch (relAttribute.value.type) {
+  case 'TextNode':
+    return relAttribute.value.chars === 'noopener';
+  default:
+    return false;
+  }
+}

--- a/test/unit/rules/lint-link-rel-noopener-test.js
+++ b/test/unit/rules/lint-link-rel-noopener-test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'link-rel-noopener',
+
+  config: true,
+
+  good: [
+    '<a href="/some/where"></a>',
+    '<a href="/some/where" target="_self"></a>',
+    '<a href="/some/where" target="_blank" rel="noopener"></a>'
+  ],
+
+  bad: [
+    {
+      template: '<a href="/some/where" target="_blank"></a>',
+
+      result: {
+        rule: 'link-rel-noopener',
+        message: 'links with target="_blank" must have rel="noopener"',
+        moduleId: 'layout.hbs',
+        source: '<a href="/some/where" target="_blank"></a>',
+        line: 1,
+        column: 0
+      }
+    },
+    {
+      template: '<a href="/some/where" target="_blank" rel="nofollow"></a>',
+
+      result: {
+        rule: 'link-rel-noopener',
+        message: 'links with target="_blank" must have rel="noopener"',
+        moduleId: 'layout.hbs',
+        source: '<a href="/some/where" target="_blank" rel="nofollow"></a>',
+        line: 1,
+        column: 0
+      }
+    }
+  ]
+});


### PR DESCRIPTION
Enabling this rule forbirds links with `target="_blank"` without `rel="noopener"`