### PR TITLE
link-rel-noopener rule contains noopener

### DIFF
--- a/lib/rules/lint-link-rel-noopener.js
+++ b/lib/rules/lint-link-rel-noopener.js
@@ -65,7 +65,7 @@ function hasRelNoopener(node) {
 
   switch (relAttribute.value.type) {
   case 'TextNode':
-    return relAttribute.value.chars === 'noopener';
+    return relAttribute.value.chars.indexOf('noopener') !== -1;
   default:
     return false;
   }

--- a/test/unit/rules/lint-link-rel-noopener-test.js
+++ b/test/unit/rules/lint-link-rel-noopener-test.js
@@ -10,7 +10,8 @@ generateRuleTests({
   good: [
     '<a href="/some/where"></a>',
     '<a href="/some/where" target="_self"></a>',
-    '<a href="/some/where" target="_blank" rel="noopener"></a>'
+    '<a href="/some/where" target="_blank" rel="noopener"></a>',
+    '<a href="/some/where" target="_blank" rel="noopener noreferrer"></a>'
   ],
 
   bad: [


### PR DESCRIPTION
Update `link-rel-noopener` rule so that `rel` contains `noopener`.