### PR TITLE
[BUGFIX] Honor `additionalInteractiveTags` option in `invalid-interactive` rule

### DIFF
--- a/lib/rules/lint-invalid-interactive.js
+++ b/lib/rules/lint-invalid-interactive.js
@@ -11,12 +11,23 @@ module.exports = function(addonContext) {
     return parseConfig(this.ruleName, config);
   };
 
+  InvalidInteractive.prototype.isCustomInteractiveElement = function(node) {
+    var additionalInteractiveTags = this.config.additionalInteractiveTags || [];
+
+    if (additionalInteractiveTags.indexOf(node.tag) > -1) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
   InvalidInteractive.prototype.visitors = function() {
     this._element = null;
 
     var visitor = {
       enter: function(node) {
-        this._element = !isInteractiveElement(node) ? node : null;
+        var isInteractive = isInteractiveElement(node) || this.isCustomInteractiveElement(node);
+        this._element = !isInteractive ? node : null;
       },
 
       exit: function(node) {

--- a/test/unit/rules/lint-invalid-interactive-test.js
+++ b/test/unit/rules/lint-invalid-interactive-test.js
@@ -10,7 +10,15 @@ generateRuleTests({
   good: [
     '<button {{action "foo"}}></button>',
     '<div role="button" {{action "foo"}}></div>',
-    '<li><button {{action "foo"}}></button></li>'
+    '<li><button {{action "foo"}}></button></li>',
+    {
+      config: { additionalInteractiveTags: ['div'] },
+      template: '<div {{action "foo"}}></div>'
+    },
+    {
+      config: { additionalInteractiveTags: ['div'] },
+      template: '<div onclick={{action "foo"}}></div>'
+    }
   ],
 
   bad: [


### PR DESCRIPTION
Closes #101