### PR TITLE
Adding More Whitelisted Characters

### DIFF
--- a/lib/rules/lint-bare-strings.js
+++ b/lib/rules/lint-bare-strings.js
@@ -34,7 +34,7 @@ var TAG_ATTRIBUTES = {
 };
 
 var DEFAULT_CONFIG = {
-  whitelist: ['(', ')', ',', '.', '&', '+', '-', '=', '*', '/', '#', '%', '!', '?', ':', '[', ']', '{', '}'],
+  whitelist: ['(', ')', ',', '.', '&', '+', '-', '=', '*', '/', '#', '%', '!', '?', ':', '[', ']', '{', '}', '<', '>', '•', '—', ' ', '|'],
   globalAttributes: GLOBAL_ATTRIBUTES,
   elementAttributes: TAG_ATTRIBUTES
 };


### PR DESCRIPTION
These are sometimes used in their bare format without the need for translations. It would be nice if they were included by default.