### PR TITLE
[Bugfix] Fixes #173

### DIFF
--- a/lib/rules/deprecations/lint-deprecated-inline-view-helper.js
+++ b/lib/rules/deprecations/lint-deprecated-inline-view-helper.js
@@ -39,7 +39,7 @@ function manageMustacheViewInvocation(context, node, isBlockStatement) {
       var currentPair = pairs[i];
       var originalValue = currentPair.value.original;
 
-      if (originalValue.split('.')[0] == 'view') {
+      if (typeof originalValue === 'string' && originalValue.split('.')[0] == 'view') {
         if (isBlockStatement) {
           context.processInBlockStatement(node, currentPair);
         } else {
@@ -65,7 +65,7 @@ module.exports = function(addonContext) {
           if (value.type === 'MustacheStatement') {
             var originalValue = value.path.original;
 
-            if (originalValue.split('.')[0] == 'view') {
+            if (typeof originalValue === 'string' && originalValue.split('.')[0] == 'view') {
               this.processAsElementAttribute(node, currentAttribute);
             }
           }

--- a/test/unit/rules/deprecations/lint-deprecated-inline-view-helper-test.js
+++ b/test/unit/rules/deprecations/lint-deprecated-inline-view-helper-test.js
@@ -12,9 +12,9 @@ generateRuleTests({
   config: true,
 
   good: [
-    {
-      template: '{{great-fishsticks}}'
-    }
+    '{{great-fishsticks}}',
+    '{{input placeholder=(t "email") value=email}}',
+    '{{title "CrossCheck Web" prepend=true separator=" | "}}'
   ],
 
   bad: [


### PR DESCRIPTION
Check if `originalValue` is a String, before spliting it