### PR TITLE
Use glimmer-engine instead of htmlbars.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-var compile = require('htmlbars').compile;
+var precompile = require('glimmer-engine').precompile;
 var plugins = require('./rules');
 var getConfig = require('./get-config');
 
@@ -83,7 +83,7 @@ Linter.prototype = {
     };
 
     try {
-      compile(options.source, {
+      precompile(options.source, {
         moduleName: options.moduleId,
         rawSource: options.source,
         plugins: {

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -22,7 +22,7 @@ module.exports = function(options) {
 
   function BasePlugin(options) {
     this.options = options;
-    this.syntax = null; // set by HTMLBars
+    this.syntax = null; // set by Glimmer
 
     // split into a source array (allow windows and posix line endings)
     this.source = this.options.rawSource.split(/(?:\r\n?|\n)/g);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "exists-sync": "0.0.4",
-    "htmlbars": "0.14.24",
+    "glimmer-engine": "^0.17.6",
     "lodash": "^4.11.1"
   },
   "bugs": {

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var assert = require('power-assert');
-var _compile = require('htmlbars').compile;
+var _precompile = require('glimmer-engine').precompile;
 var buildPlugin = require('./../../lib/rules/base');
 
 describe('base plugin tests', function() {
@@ -42,8 +42,8 @@ describe('base plugin tests', function() {
     return FakePlugin;
   }
 
-  function compile(template) {
-    _compile(template, {
+  function precompile(template) {
+    _precompile(template, {
       rawSource: template,
       moduleName: 'layout.hbs',
       plugins: {
@@ -64,7 +64,7 @@ describe('base plugin tests', function() {
     var nodeSources = config.sources;
 
     it('can get raw source for `' + template + '`', function() {
-      compile(template);
+      precompile(template);
 
       assert.deepEqual(messages, nodeSources);
     });

--- a/test/unit/helpers/ast-node-info-test.js
+++ b/test/unit/helpers/ast-node-info-test.js
@@ -1,35 +1,35 @@
 var assert = require('power-assert');
-var parse = require('htmlbars/dist/cjs/htmlbars-syntax').parse;
+var preprocess = require('glimmer-engine/dist/node_modules/glimmer-syntax').preprocess;
 var AstNodeInfo = require('../../../lib/helpers/ast-node-info');
 
 describe('isImgElement', function() {
   it('can detect an image tag', function() {
-    var tableAst = parse('<table></table>');
+    var tableAst = preprocess('<table></table>');
     assert(AstNodeInfo.isImgElement(tableAst.body[0]) === false);
 
-    var imgAst = parse('<img />');
+    var imgAst = preprocess('<img />');
     assert(AstNodeInfo.isImgElement(imgAst.body[0]) === true);
   });
 });
 
 describe('hasChildren', function() {
   it('functions for empty input', function() {
-    assert(AstNodeInfo.hasChildren(parse('')) === false);
+    assert(AstNodeInfo.hasChildren(preprocess('')) === false);
   });
 
   it('functions for empty elements', function() {
-    var ast = parse('<div></div>');
+    var ast = preprocess('<div></div>');
     assert(AstNodeInfo.hasChildren(ast.body[0]) === false);
     assert(AstNodeInfo.hasChildren(ast) === true);
   });
 
   it('detects text', function() {
-    var ast = parse('<div>hello</div>');
+    var ast = preprocess('<div>hello</div>');
     assert(AstNodeInfo.hasChildren(ast.body[0]) === true);
   });
 
   it('detects whitespace', function() {
-    var ast = parse('<div> </div>');
+    var ast = preprocess('<div> </div>');
     assert(AstNodeInfo.hasChildren(ast.body[0]) === true);
   });
 });

--- a/test/unit/helpers/is-interactive-element-test.js
+++ b/test/unit/helpers/is-interactive-element-test.js
@@ -1,11 +1,11 @@
 var assert = require('power-assert');
-var parse = require('htmlbars/dist/cjs/htmlbars-syntax').parse;
+var preprocess = require('glimmer-engine/dist/node_modules/glimmer-syntax').preprocess;
 var isInteractiveElement = require('../../../lib/helpers/is-interactive-element');
 
 describe('isInteractiveElement', function() {
   function testTemplate(template, expectedValue) {
     it('isInteractiveElement(`' + template + '` should be ' + expectedValue, function() {
-      var ast = parse(template);
+      var ast = preprocess(template);
 
       var interactive = isInteractiveElement(ast.body[0]);
 
@@ -15,7 +15,7 @@ describe('isInteractiveElement', function() {
 
   function testReason(template, expectedReason) {
     it('isInteractiveElement.reason(`' + template + '` should be `' + expectedReason+ '`', function() {
-      var ast = parse(template);
+      var ast = preprocess(template);
 
       var reason = isInteractiveElement.reason(ast.body[0]);
 
@@ -59,7 +59,7 @@ describe('isInteractiveElement', function() {
 
   describe('reason', function() {
     function test(template) {
-      var ast = parse(template);
+      var ast = preprocess(template);
 
       return isInteractiveElement.reason(ast.body[0]);
     }

--- a/test/unit/linting-compiler-test.js
+++ b/test/unit/linting-compiler-test.js
@@ -1,13 +1,13 @@
 'use strict';
 
 var assert = require('power-assert');
-var _compile = require('htmlbars').compile;
+var _precompile = require('glimmer-engine').precompile;
 
 describe('Ember template compiler', function() {
   var astPlugins;
 
-  function compile(template) {
-    return _compile(template, {
+  function precompile(template) {
+    return _precompile(template, {
       rawSource: template,
       plugins: {
         ast: astPlugins
@@ -20,7 +20,7 @@ describe('Ember template compiler', function() {
   });
 
   it('sanity: compiles templates', function() {
-    var template = compile('<div></div>');
+    var template = precompile('<div></div>');
     assert.ok(template, 'template is created');
   });
 
@@ -33,7 +33,7 @@ describe('Ember template compiler', function() {
       return ast;
     };
     astPlugins.push(NoopPlugin);
-    compile('<div></div>');
+    precompile('<div></div>');
 
     assert.equal(instanceCount, 1, 'registered plugins are instantiated');
   });
@@ -48,7 +48,7 @@ describe('Ember template compiler', function() {
     };
     astPlugins.push(NoopPlugin);
     var expectedTemplate = '<div></div>';
-    compile(expectedTemplate);
+    precompile(expectedTemplate);
 
     assert.equal(expectedTemplate, options.rawSource, 'rawSource can be passed through compile options');
   });


### PR DESCRIPTION
This will allow us to make future changes only to
tildeio/glimmer (instead of both tildeio/glimmer and tildeio/htmlbars),
and sets the stage to be able to easily update to using glimmer-engine
for retrieving Handlebars comments in the AST.