### PR TITLE
Update glimmer-engine to 0.17.8.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "exists-sync": "0.0.4",
-    "glimmer-engine": "^0.17.6",
+    "glimmer-engine": "^0.17.8",
     "lodash": "^4.11.1"
   },
   "bugs": {


### PR DESCRIPTION
Adds support for detecting Handlebars comments.