### PR TITLE
Handlebars comment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,19 +87,19 @@ It is also possible to disable specific rules (or all rules) in a template itsel
 <!-- disable all rules -->
 {{! template-lint-disable }}
 
-<!-- disable only bare-strings -->
+<!-- disable bare-strings -->
 {{! template-lint-disable bare-strings }}
 
-<!-- disable only bare-strings and triple-curlies -->
+<!-- disable bare-strings and triple-curlies -->
 {{! template-lint-disable bare-strings triple-curlies }}
 
 <!-- enable all rules -->
 {{! template-lint-enable }}
 
-<!-- enable only bare-strings -->
+<!-- enable bare-strings -->
 {{! template-lint-enable bare-strings }}
 
-<!-- enable only bare-strings and triple-curlies -->
+<!-- enable bare-strings and triple-curlies -->
 {{! template-lint-enable bare-strings triple-curlies }}
 ```
 
@@ -151,6 +151,8 @@ An in-element instruction with the `-tree` suffix will apply to that element and
   </p>
 </div>
 ```
+
+Note that enabling a rule (`{{! template-lint-enable }}`) that has been configured in-template (`{{! template-lint-configure }}`), will restore it to its default configuration rather than the modified in-template configuration for the scope of the `{{! template-lint-enable }}` instruction.
 
 ### Configuration Keys
 

--- a/README.md
+++ b/README.md
@@ -84,14 +84,73 @@ module.exports = {
 It is also possible to disable specific rules (or all rules) in a template itself:
 
 ```hbs
-{{! disable all rules for this template }}
-<!-- template-lint disable=true -->
+<!-- disable all rules -->
+{{! template-lint-disable }}
 
-{{! disable specific rules for this template }}
-<!-- template-lint bare-strings=false -->
+<!-- disable only bare-strings -->
+{{! template-lint-disable bare-strings }}
+
+<!-- disable only bare-strings and triple-curlies -->
+{{! template-lint-disable bare-strings triple-curlies }}
+
+<!-- enable all rules -->
+{{! template-lint-enable }}
+
+<!-- enable only bare-strings -->
+{{! template-lint-enable bare-strings }}
+
+<!-- enable only bare-strings and triple-curlies -->
+{{! template-lint-enable bare-strings triple-curlies }}
 ```
 
-It is not currently possible to change rule configuration in the template.
+and to configure rules in the template:
+
+```hbs
+{{! template-lint-configure bare-strings ["ZOMG THIS IS ALLOWED!!!!"] }}
+
+{{! template-lint-configure bare-strings {"whitelist": "(),.", "globalAttributes": ["title"]} }}
+```
+
+The configure instruction can only configure a single rule, and the configuration value must be valid JSON that parses into a configuration for that rule.
+
+These configuration instructions do not modify the rule for the rest of the template, but instead modify it within whatever DOM scope the comment instruction appears.
+
+An instruction will apply to all later siblings and their descendants:
+
+```hbs
+<!-- disable for <p> and <span> and their contents, but not for <div> or <hr> -->
+<div>
+  <hr>
+  {{! template-lint-disable }}
+  <p>
+    <span>Hello!</span>
+  </p>
+</div>
+```
+
+An in-element instruction will apply to only that element:
+
+```hbs
+<!-- enable for <p>, but not for <div>, <hr> or <span> -->
+<div>
+  <hr>
+  <p {{! template-lint-enable }}>
+    <span>Hello!</span>
+  </p>
+</div>
+```
+
+An in-element instruction with the `-tree` suffix will apply to that element and all its descendants:
+
+```hbs
+<!-- configure for <p>, <span> and their contents, but not for <div> or <hr> -->
+<div>
+  <hr>
+  <p {{! template-lint-configure-tree block-indentation "tab" }}>
+    <span>Hello!</span>
+  </p>
+</div>
+```
 
 ### Configuration Keys
 
@@ -173,15 +232,6 @@ but allows the following:
 ```hbs
 {{!-- comment goes here --}}
 ```
-
-Html comments containing linting instructions such as:
-
-```hbs
-<!-- template-lint bare-strings=false -->
-```
-
-are of course allowed (and since the linter strips them during processing, they will not get compiled and rendered into the DOM regardless of this rule).
-
 
 #### triple-curlies
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ function Linter(_options) {
   var options = _options || {};
 
   this.options = options;
-  this.console = options.console || {};
+  this.console = options.console || console;
 
   this.loadConfig();
 }
@@ -48,6 +48,7 @@ Linter.prototype = {
       var plugin = plugins[pluginName]({
         name: pluginName,
         config: this.config.rules[pluginName],
+        console: this.console,
         log: addToResults,
         defaultSeverity: this._defaultSeverityForRule(pluginName, config.pending)
       });

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -1,18 +1,7 @@
 'use strict';
 
-var assign = require('lodash').assign;
-
-function invokeVisitorEnter(visitor, args, thisContext) {
-  var func;
-
-  if (typeof visitor === 'function') {
-    func = visitor;
-  } else if (visitor && visitor.enter) {
-    func = visitor.enter;
-  }
-
-  return func.apply(thisContext, args);
-}
+var _ = require('lodash');
+var assign = _.assign;
 
 module.exports = function(options) {
   var log = options.log;
@@ -30,7 +19,13 @@ module.exports = function(options) {
     this._log = log;
     this.ruleName = ruleName;
     this.severity = defaultSeverity;
+    // To support DOM-scoped configuration instructions, we need to maintain
+    // a stack of our configurations so we can restore the previous one when
+    // the current one goes out of scope. The current one is duplicated in
+    // this.config so the rule implementations don't need to worry about the
+    // fact that there is a stack.
     this.config = this.parseConfig(config);
+    this.configStack = [this.config];
   }
 
   BasePlugin.prototype.parseConfig = function(config) {
@@ -48,57 +43,257 @@ module.exports = function(options) {
     var pluginContext = this;
     var visitors = {};
     var ruleVisitors = this.visitors();
-    var ruleVisitor;
+    // We use this structure to advise/unadvise on AST events. The walkers we
+    // set up read this structure every time they get an AST event and call the
+    // appropriate functions. Handlers get added to the before/after list
+    // according to whether they will be called before/after the rule's AST
+    // event handlers.
+    var astHandlers = {
+      CommentStatement: {
+        enter: { before: [], after: [] },
+        exit: { before: [], after: [] }
+      },
+      MustacheCommentStatement: {
+        enter: { before: [], after: [] },
+        exit: { before: [], after: [] }
+      },
+      ElementNode: {
+        enter: { before: [], after: [] },
+        exit: { before: [], after: [] },
+        keys: {
+          children: {
+            enter: { before: [], after: [] },
+            exit: { before: [], after: [] }
+          },
+          comments: {
+            enter: { before: [], after: [] },
+            exit: { before: [], after: [] }
+          }
+        }
+      }
+    };
+    // Keep a stack of ancestor elements so that when we encounter a comment
+    // that is the child of an element (i.e. not within the element's tag)
+    // we know what it's parent is so we can set up a listener for when we
+    // leave the comment's siblings.
+    var elementStack = [];
+    // We don't traverse in-element comments until after we've entered the
+    // element, but we need to apply such instructions before we enter the
+    // element. So, we have an element enter handler that processes that
+    // element's comments, which means we need to distinguish in-element
+    // comments from child-of-element comments during the traverse so we can
+    // ignore the former, but still process the latter.
+    var inElementComments = false;
 
+    //
+    // Wrap all visitors supplied by the rule, plus make sure we have entries
+    // for the visitors we use internally for instruction processing. This is
+    // done for two reasons -- one is to support instruction processing, but
+    // the other is to allow the rule's visitor handlers to have their this
+    // context set to the plugin, which isn't what HTMLBars does.
+    //
     for (var key in ruleVisitors) {
-      ruleVisitor = ruleVisitors[key];
-
-      visitors[key] = this.processVisitor(ruleVisitor);
+      visitors[key] = this._wrapVisitor(ruleVisitors[key], astHandlers[key]);
     }
 
-    var commentVisitor = visitors['CommentStatement'];
-    if (!commentVisitor) {
-      commentVisitor = visitors['CommentStatement'] = { enter: function() {} };
-    }
+    visitors.CommentStatement = visitors.CommentStatement || this._wrapVisitor(null, astHandlers.CommentStatement);
+    visitors.MustacheCommentStatement = visitors.MustacheCommentStatement || this._wrapVisitor(null, astHandlers.MustacheCommentStatement);
+    visitors.ElementNode = visitors.ElementNode || this._wrapVisitor(null, astHandlers.ElementNode);
 
-    var commentVisitorEnter = commentVisitor.enter;
-    if (commentVisitorEnter) {
-      commentVisitor.enter = function(node) {
-        if (node.value.indexOf('template-lint') > -1) {
-          pluginContext._processConfigNode(node);
+    //
+    // Set up our handlers
+    //
+
+    // Manage elementStack
+    astHandlers.ElementNode.keys.children.enter.before.push(function(elementNode) {
+      elementStack.push(elementNode);
+    });
+    astHandlers.ElementNode.keys.children.exit.after.push(function(elementNode) {
+      if (elementNode !== _.last(elementStack)) {
+        throw new Error('Element stack out of sync with AST!');
+      }
+      elementStack.pop();
+    });
+
+    // Manage inElementComments
+    astHandlers.ElementNode.keys.comments.enter.before.push(function() {
+      inElementComments = true;
+    });
+    astHandlers.ElementNode.keys.comments.exit.after.push(function() {
+      if (!inElementComments) {
+        throw new Error('Element comments state out of sync with AST!');
+      }
+      inElementComments = false;
+    });
+
+    // Handle legacy config statements
+    astHandlers.CommentStatement.enter.after.push(function(node) {
+      if (node.value.indexOf('template-lint') === -1) {
+        return;
+      }
+
+      // TODO: deprecation warning
+      pluginContext._processLegacyConfigNode(node);
+    });
+
+    // Handle element-child config statements
+    astHandlers.MustacheCommentStatement.enter.after.push(function(commentNode) {
+      if (inElementComments) {
+        return;
+      }
+
+      var config = pluginContext._processInstructionNode(commentNode);
+      if (!config) {
+        return;
+      }
+
+      pluginContext._pushConfig(config.value);
+
+      // Pop the config once we exit the comment's siblings
+      var parentNode = _.last(elementStack);
+      astHandlers.ElementNode.keys.children.exit.before.unshift(function(elementNode) {
+        if (elementNode === parentNode) {
+          pluginContext._popConfig(config.value);
+          return false;
+        }
+      });
+    });
+
+    // Handle in-element config statements
+    astHandlers.ElementNode.enter.before.push(function(elementNode) {
+      elementNode.comments.forEach(function(commentNode) {
+        var config = pluginContext._processInstructionNode(commentNode);
+        if (!config) {
+          return;
         }
 
-        commentVisitorEnter.apply(this, arguments);
-      };
-    }
+        pluginContext._pushConfig(config.value);
+
+        if (config.tree) {
+          // Applies to descendants, so pop the config once we exit the
+          // comment's element
+          astHandlers.ElementNode.exit.after.unshift(function(node) {
+            if (node === elementNode) {
+              pluginContext._popConfig(config.value);
+              return false;
+            }
+          });
+        } else {
+          // Applies to only this element, so pop the config when we enter the
+          // element's children, re-push it when we exit the element's
+          // children, and then re-pop it when we exit the element entirely.
+          astHandlers.ElementNode.keys.children.enter.before.unshift(function(node) {
+            if (node === elementNode) {
+              pluginContext._popConfig(config.value);
+              return false;
+            }
+          });
+          astHandlers.ElementNode.keys.children.exit.after.push(function(node) {
+            if (node === elementNode) {
+              pluginContext._pushConfig(config.value);
+              return false;
+            }
+          });
+          astHandlers.ElementNode.exit.after.unshift(function(node) {
+            if (node === elementNode) {
+              pluginContext._popConfig(config.value);
+              return false;
+            }
+          });
+        }
+      });
+    });
 
     return visitors;
   };
 
-  BasePlugin.prototype.processVisitor = function(ruleVisitor) {
-    var pluginContext = this;
-    var visitor = {
-      enter: function(node) {
-        if (!pluginContext.isDisabled()) {
-          invokeVisitorEnter(ruleVisitor, [node], pluginContext);
+  BasePlugin.prototype.visitors = function() { };
+
+  // Generate a visitor handler function for a specific node type/event that
+  // will call the internal handlers and the rule handler for that node
+  // type/event in the correct order.
+  BasePlugin.prototype._wrapVisitorHandler = function(ruleHandler, internalHandlers) {
+    internalHandlers = internalHandlers || {};
+    var beforeHandlers = internalHandlers.before || [];
+    var afterHandlers = internalHandlers.after || [];
+    var plugin = this;
+    var i, ret;
+
+    return function() {
+      for (i = 0; i < beforeHandlers.length; i++) {
+        ret = beforeHandlers[i].apply(plugin, arguments);
+        if (ret === false) {
+          beforeHandlers.splice(i, 1);
+          i -= 1;
+        }
+      }
+
+      if (ruleHandler && !plugin.isDisabled()) {
+        ruleHandler.apply(plugin, arguments);
+      }
+
+      for (i = 0; i < afterHandlers.length; i++) {
+        ret = afterHandlers[i].apply(plugin, arguments);
+        if (ret === false) {
+          afterHandlers.splice(i, 1);
+          i -= 1;
         }
       }
     };
-
-    if (ruleVisitor && ruleVisitor.exit) {
-      visitor.exit = function(node) {
-        if (!pluginContext.isDisabled()) {
-          ruleVisitor.exit.apply(pluginContext, [node]);
-        }
-      };
-    }
-
-    return visitor;
   };
 
-  BasePlugin.prototype.visitors = function() { };
+  // Give the rule's visitor for a given node type, and our internal
+  // astHandlers registry for that node type, generate a visitor that will
+  // call all the various event handlers in the proper order
+  BasePlugin.prototype._wrapVisitor = function(ruleVisitor, astHandlers) {
+    if (typeof ruleVisitor === 'function') {
+      ruleVisitor = { enter: ruleVisitor };
+    }
 
-  BasePlugin.prototype._processConfigNode = function(node) {
+    ruleVisitor = ruleVisitor || {};
+    astHandlers = astHandlers || {};
+
+    var visitorKeys = ruleVisitor.keys || {};
+    var visitorChildren = visitorKeys.children || {};
+    var visitorComments = visitorKeys.comments || {};
+    var internalKeys = astHandlers.keys || {};
+    var internalChildren = internalKeys.children || {};
+    var internalComments = internalKeys.comments || {};
+
+    return {
+      enter: this._wrapVisitorHandler(ruleVisitor.enter, astHandlers.enter),
+      exit: this._wrapVisitorHandler(ruleVisitor.exit, astHandlers.exit),
+      keys: {
+        children: {
+          enter: this._wrapVisitorHandler(visitorChildren.enter, internalChildren.enter),
+          exit: this._wrapVisitorHandler(visitorChildren.exit, internalChildren.exit)
+        },
+        comments: {
+          enter: this._wrapVisitorHandler(visitorComments.enter, internalComments.enter),
+          exit: this._wrapVisitorHandler(visitorComments.exit, internalComments.exit)
+        }
+      }
+    };
+  };
+
+  BasePlugin.prototype._pushConfig = function(config) {
+    this.configStack.push(config);
+    this.config = config;
+  };
+
+  BasePlugin.prototype._popConfig = function(config) {
+    if (_.last(this.configStack) !== config) {
+      throw new Error('Configuration stack out of sync with AST!');
+    }
+
+    this.configStack.pop();
+    this.config = _.last(this.configStack);
+  };
+
+  BasePlugin.prototype._processInstructionNode = function(/*node*/) {
+  };
+
+  BasePlugin.prototype._processLegacyConfigNode = function(node) {
     var hashParts = node.value
           .trim()
           .slice(14)
@@ -114,14 +309,21 @@ module.exports = function(options) {
 
     for (var key in hash) {
       var value = hash[key];
+      var i;
 
       // handle <!-- template-lint disabled=true -->
       if (key === 'disable' && value === 'true') {
+        for (i = 0; i < this.configStack.length; i++) {
+          this.configStack[i] = false;
+        }
         this.config = false;
       }
 
       // handle <!-- template-lint block-indentation=false -->
       if (key === ruleName && value === 'false') {
+        for (i = 0; i < this.configStack.length; i++) {
+          this.configStack[i] = false;
+        }
         this.config = false;
       }
     }

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -290,7 +290,50 @@ module.exports = function(options) {
     this.config = _.last(this.configStack);
   };
 
-  BasePlugin.prototype._processInstructionNode = function(/*node*/) {
+  BasePlugin.prototype._processInstructionNode = function(node) {
+    var nodeValue = node.value.trim();
+    var instructionName = nodeValue.split(/\s/)[0];
+    var instructionArgs = nodeValue.slice(instructionName.length + 1).trim();
+    var config = { tree: false };
+    var m;
+
+    m = /^(.*)-tree$/.exec(instructionName);
+    if (m) {
+      config.tree = true;
+      instructionName = m[1];
+    }
+
+    m = /^template-lint-(enable|disable)$/.exec(instructionName);
+    if (m) {
+      // It either disables all rules (no instruction args), or it disables an
+      // explicit list of rules.
+      if (instructionArgs && instructionArgs.split(/\s/).indexOf(ruleName) === -1) {
+        // Explicit list that doesn't include us
+        return null;
+      }
+
+      config.value = (m[1] === 'enable');
+      return config;
+    } else if (instructionName === 'template-lint-configure') {
+      // This instruction must list exactly one rule
+      if (instructionArgs.split(/\s/)[0] !== ruleName) {
+        return null;
+      }
+
+      try {
+        config.value = JSON.parse(instructionArgs.slice(ruleName.length).trim());
+        return config;
+      } catch (e) {
+        this.log({
+          message: 'malformed template-lint-configure instruction',
+          line: node.loc && node.loc.start.line,
+          column: node.loc && node.loc.start.column,
+          source: this.sourceForNode(node)
+        });
+      }
+    }
+
+    return null;
   };
 
   BasePlugin.prototype._processLegacyConfigNode = function(node) {

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -399,7 +399,19 @@ module.exports = function(options) {
         }
       }
 
-      config.value = (m[1] === 'enable');
+      if (m[1] === 'disable') {
+        config.value = false;
+      } else {
+        // Enable means set to the default config, i.e. the bottom of our
+        // config stack...unless it was originally disabled, and then just
+        // enable it.
+        if (this._configStack[0] === false) {
+          config.value = true;
+        } else {
+          config.value = this._configStack[0];
+        }
+      }
+
       return config;
     } else if (instructionName === 'template-lint-configure') {
       // This instruction must list exactly one rule

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -3,18 +3,54 @@
 var _ = require('lodash');
 var assign = _.assign;
 
+// Constant to return from AST handlers so we know to remove/unregister them
+var REMOVE_HANDLER = {};
+
+// If a comment instruction node contains a syntax error, we want to only log
+// it once, rather than having every rule log it, spamming the user. So the
+// rules push any nodes with syntax errors into this array so only the first
+// one will log the error, and subsequent rules will see it already in the
+// array and not log it.
+var syntaxErrorNodes = [];
+
+var reLineEnds = /(?:\r\n?|\n)/;
+var reWhitespace = /\s+/;
+var reTree = /^(.*)-tree$/;
+var reToggleRule = /^template-lint-(enable|disable)$/;
+
+function unquote(str) {
+  if (str.length < 3) {
+    return str;
+  }
+
+  // Allow single or double quotes
+  var firstLetter = str[0];
+  var lastLetter = str[str.length - 1];
+  if (firstLetter === lastLetter && ['"', '\''].indexOf(firstLetter) > -1) {
+    return str.slice(1, -1);
+  }
+  return str;
+}
+
 module.exports = function(options) {
+  var allRules = require('./index');
   var log = options.log;
   var config = options.config;
   var ruleName = options.name;
   var defaultSeverity = options.defaultSeverity;
+
+  // The `firstArg !== ruleName` check isn't strictly necessary, but allows
+  // unit tests to register test rules
+  function isRuleName(name) {
+    return allRules[name] || name === ruleName;
+  }
 
   function BasePlugin(options) {
     this.options = options;
     this.syntax = null; // set by Glimmer
 
     // split into a source array (allow windows and posix line endings)
-    this.source = this.options.rawSource.split(/(?:\r\n?|\n)/g);
+    this.source = this.options.rawSource.split(reLineEnds);
 
     this._log = log;
     this.ruleName = ruleName;
@@ -25,7 +61,7 @@ module.exports = function(options) {
     // this.config so the rule implementations don't need to worry about the
     // fact that there is a stack.
     this.config = this.parseConfig(config);
-    this.configStack = [this.config];
+    this._configStack = [this.config];
   }
 
   BasePlugin.prototype.parseConfig = function(config) {
@@ -154,7 +190,7 @@ module.exports = function(options) {
       astHandlers.ElementNode.keys.children.exit.before.unshift(function(elementNode) {
         if (elementNode === parentNode) {
           pluginContext._popConfig(config.value);
-          return false;
+          return REMOVE_HANDLER;
         }
       });
     });
@@ -175,29 +211,33 @@ module.exports = function(options) {
           astHandlers.ElementNode.exit.after.unshift(function(node) {
             if (node === elementNode) {
               pluginContext._popConfig(config.value);
-              return false;
+              return REMOVE_HANDLER;
             }
           });
         } else {
           // Applies to only this element, so pop the config when we enter the
           // element's children, re-push it when we exit the element's
           // children, and then re-pop it when we exit the element entirely.
+          // This is so that if the rule is listening for element exit events
+          // for some reason, the configuration will be applied when they fire,
+          // like it is applied when the enter events fire (but not applied when
+          // entering/exiting or traversing the children).
           astHandlers.ElementNode.keys.children.enter.before.unshift(function(node) {
             if (node === elementNode) {
               pluginContext._popConfig(config.value);
-              return false;
+              return REMOVE_HANDLER;
             }
           });
           astHandlers.ElementNode.keys.children.exit.after.push(function(node) {
             if (node === elementNode) {
               pluginContext._pushConfig(config.value);
-              return false;
+              return REMOVE_HANDLER;
             }
           });
           astHandlers.ElementNode.exit.after.unshift(function(node) {
             if (node === elementNode) {
               pluginContext._popConfig(config.value);
-              return false;
+              return REMOVE_HANDLER;
             }
           });
         }
@@ -222,7 +262,7 @@ module.exports = function(options) {
     return function() {
       for (i = 0; i < beforeHandlers.length; i++) {
         ret = beforeHandlers[i].apply(plugin, arguments);
-        if (ret === false) {
+        if (ret === REMOVE_HANDLER) {
           beforeHandlers.splice(i, 1);
           i -= 1;
         }
@@ -234,7 +274,7 @@ module.exports = function(options) {
 
       for (i = 0; i < afterHandlers.length; i++) {
         ret = afterHandlers[i].apply(plugin, arguments);
-        if (ret === false) {
+        if (ret === REMOVE_HANDLER) {
           afterHandlers.splice(i, 1);
           i -= 1;
         }
@@ -277,59 +317,126 @@ module.exports = function(options) {
   };
 
   BasePlugin.prototype._pushConfig = function(config) {
-    this.configStack.push(config);
+    this._configStack.push(config);
     this.config = config;
   };
 
   BasePlugin.prototype._popConfig = function(config) {
-    if (_.last(this.configStack) !== config) {
+    if (_.last(this._configStack) !== config) {
       throw new Error('Configuration stack out of sync with AST!');
     }
 
-    this.configStack.pop();
-    this.config = _.last(this.configStack);
+    this._configStack.pop();
+    this.config = _.last(this._configStack);
   };
 
   BasePlugin.prototype._processInstructionNode = function(node) {
     var nodeValue = node.value.trim();
-    var instructionName = nodeValue.split(/\s/)[0];
+    var instructionName = nodeValue.split(reWhitespace)[0];
     var instructionArgs = nodeValue.slice(instructionName.length + 1).trim();
     var config = { tree: false };
     var m;
 
-    m = /^(.*)-tree$/.exec(instructionName);
+    m = reTree.exec(instructionName);
     if (m) {
       config.tree = true;
       instructionName = m[1];
     }
 
-    m = /^template-lint-(enable|disable)$/.exec(instructionName);
+    m = reToggleRule.exec(instructionName);
     if (m) {
-      // It either disables all rules (no instruction args), or it disables an
-      // explicit list of rules.
-      if (instructionArgs && instructionArgs.split(/\s/).indexOf(ruleName) === -1) {
-        // Explicit list that doesn't include us
-        return null;
+      // If no instructionArgs, it's just disabling everything, so apply the
+      // config
+      if (instructionArgs) {
+        // It includes an explicit list of rules, so not just disabling
+        // everything. So, let's validate the rule names, and then see if it
+        // contains us.
+        var names = instructionArgs.split(reWhitespace).map(unquote);
+
+        // Validate rule names. If one or more fail to validate, don't return,
+        // though, because if we can still find our rule name in the list, we
+        // can process the instruction just fine.
+        if (syntaxErrorNodes.indexOf(node) === -1) {
+          var badNames = names.filter(function(name) {
+            return !isRuleName(name);
+          });
+          for (var i = 0; i < badNames.length; i++) {
+            this.log({
+              message: 'unrecognized rule name `' + badNames[i] + '` in ' + instructionName + ' instruction',
+              line: node.loc && node.loc.start.line,
+              column: node.loc && node.loc.start.column,
+              source: this.sourceForNode(node),
+              rule: 'global'
+            });
+          }
+
+          if (badNames.length > 0) {
+            syntaxErrorNodes.push(node);
+          }
+        }
+
+        if (names.indexOf(ruleName) === -1) {
+          // Explicit list that doesn't include us
+          return null;
+        }
       }
 
       config.value = (m[1] === 'enable');
       return config;
     } else if (instructionName === 'template-lint-configure') {
       // This instruction must list exactly one rule
-      if (instructionArgs.split(/\s/)[0] !== ruleName) {
+      var firstArg = instructionArgs.split(reWhitespace)[0];
+      var jsonString = instructionArgs.slice(firstArg.length).trim();
+
+      firstArg = unquote(firstArg);
+
+      // Make sure the first argument is a valid rule name as a heuristic to
+      // check for syntax errors.
+      if (!isRuleName(firstArg)) {
+        // Invalid rule
+        if (syntaxErrorNodes.indexOf(node) === -1) {
+          this.log({
+            message: 'unrecognized rule name `' + firstArg + '` in template-lint-configure instruction',
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node),
+            rule: 'global'
+          });
+          syntaxErrorNodes.push(node);
+        }
+        return;
+      }
+
+      if (firstArg !== ruleName) {
+        // Valid rule, but not us, so not relevant
         return null;
       }
 
       try {
-        config.value = JSON.parse(instructionArgs.slice(ruleName.length).trim());
+        config.value = JSON.parse(jsonString);
         return config;
       } catch (e) {
+        if (syntaxErrorNodes.indexOf(node) === -1) {
+          this.log({
+            message: 'malformed template-lint-configure instruction: `' + jsonString + '` is not valid JSON',
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node),
+            rule: 'global'
+          });
+          syntaxErrorNodes.push(node);
+        }
+      }
+    } else if (instructionName.slice(0, 'template-lint'.length) === 'template-lint') {
+      if (syntaxErrorNodes.indexOf(node) === -1) {
         this.log({
-          message: 'malformed template-lint-configure instruction',
+          message: 'unrecognized template-lint instruction: `' + instructionName + '`',
           line: node.loc && node.loc.start.line,
           column: node.loc && node.loc.start.column,
-          source: this.sourceForNode(node)
+          source: this.sourceForNode(node),
+          rule: 'global'
         });
+        syntaxErrorNodes.push(node);
       }
     }
 
@@ -340,7 +447,7 @@ module.exports = function(options) {
     var hashParts = node.value
           .trim()
           .slice(14)
-          .split(/\s+/);
+          .split(reWhitespace);
 
     var hash = hashParts.reduce(function(memo, part) {
       var parts = part.split('=');
@@ -356,16 +463,16 @@ module.exports = function(options) {
 
       // handle <!-- template-lint disabled=true -->
       if (key === 'disable' && value === 'true') {
-        for (i = 0; i < this.configStack.length; i++) {
-          this.configStack[i] = false;
+        for (i = 0; i < this._configStack.length; i++) {
+          this._configStack[i] = false;
         }
         this.config = false;
       }
 
       // handle <!-- template-lint block-indentation=false -->
       if (key === ruleName && value === 'false') {
-        for (i = 0; i < this.configStack.length; i++) {
-          this.configStack[i] = false;
+        for (i = 0; i < this._configStack.length; i++) {
+          this._configStack[i] = false;
         }
         this.config = false;
       }

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -2,16 +2,18 @@
 
 var _ = require('lodash');
 var assign = _.assign;
+var chalk = require('chalk');
+var calculateLocationDisplay = require('../helpers/calculate-location-display');
 
 // Constant to return from AST handlers so we know to remove/unregister them
 var REMOVE_HANDLER = {};
 
-// If a comment instruction node contains a syntax error, we want to only log
-// it once, rather than having every rule log it, spamming the user. So the
-// rules push any nodes with syntax errors into this array so only the first
-// one will log the error, and subsequent rules will see it already in the
-// array and not log it.
-var syntaxErrorNodes = [];
+// If we need to log an error or warning about an instruction node (e.g. syntax
+// error), we want to only log it once, rather than having every rule log it,
+// spamming the user. So the rules push any nodes with syntax errors into this
+// array so only the first one will log the error, and subsequent rules will
+// see it already in the array and not log it.
+var loggedNodes = [];
 
 var reLineEnds = /(?:\r\n?|\n)/;
 var reWhitespace = /\s+/;
@@ -34,6 +36,7 @@ function unquote(str) {
 
 module.exports = function(options) {
   var allRules = require('./index');
+  var console = options.console || console;
   var log = options.log;
   var config = options.config;
   var ruleName = options.name;
@@ -52,6 +55,7 @@ module.exports = function(options) {
     // split into a source array (allow windows and posix line endings)
     this.source = this.options.rawSource.split(reLineEnds);
 
+    this._console = console;
     this._log = log;
     this.ruleName = ruleName;
     this.severity = defaultSeverity;
@@ -168,7 +172,21 @@ module.exports = function(options) {
         return;
       }
 
-      // TODO: deprecation warning
+      if (loggedNodes.indexOf(node) === -1) {
+        var locationInfo = calculateLocationDisplay(pluginContext.options.moduleName, {
+          line: node.loc.start.line,
+          column: node.loc.start.column
+        });
+
+        pluginContext._console.log(chalk.yellow([
+          'HTML comment rule instructions are deprecated. ',
+          'Please switch to Handlebars comments. ',
+          '(' + locationInfo + ')\n',
+          pluginContext.sourceForNode(node)
+        ].join('')));
+        loggedNodes.push(node);
+      }
+
       pluginContext._processLegacyConfigNode(node);
     });
 
@@ -356,7 +374,7 @@ module.exports = function(options) {
         // Validate rule names. If one or more fail to validate, don't return,
         // though, because if we can still find our rule name in the list, we
         // can process the instruction just fine.
-        if (syntaxErrorNodes.indexOf(node) === -1) {
+        if (loggedNodes.indexOf(node) === -1) {
           var badNames = names.filter(function(name) {
             return !isRuleName(name);
           });
@@ -371,7 +389,7 @@ module.exports = function(options) {
           }
 
           if (badNames.length > 0) {
-            syntaxErrorNodes.push(node);
+            loggedNodes.push(node);
           }
         }
 
@@ -394,7 +412,7 @@ module.exports = function(options) {
       // check for syntax errors.
       if (!isRuleName(firstArg)) {
         // Invalid rule
-        if (syntaxErrorNodes.indexOf(node) === -1) {
+        if (loggedNodes.indexOf(node) === -1) {
           this.log({
             message: 'unrecognized rule name `' + firstArg + '` in template-lint-configure instruction',
             line: node.loc && node.loc.start.line,
@@ -402,7 +420,7 @@ module.exports = function(options) {
             source: this.sourceForNode(node),
             rule: 'global'
           });
-          syntaxErrorNodes.push(node);
+          loggedNodes.push(node);
         }
         return;
       }
@@ -416,7 +434,7 @@ module.exports = function(options) {
         config.value = JSON.parse(jsonString);
         return config;
       } catch (e) {
-        if (syntaxErrorNodes.indexOf(node) === -1) {
+        if (loggedNodes.indexOf(node) === -1) {
           this.log({
             message: 'malformed template-lint-configure instruction: `' + jsonString + '` is not valid JSON',
             line: node.loc && node.loc.start.line,
@@ -424,11 +442,11 @@ module.exports = function(options) {
             source: this.sourceForNode(node),
             rule: 'global'
           });
-          syntaxErrorNodes.push(node);
+          loggedNodes.push(node);
         }
       }
     } else if (instructionName.slice(0, 'template-lint'.length) === 'template-lint') {
-      if (syntaxErrorNodes.indexOf(node) === -1) {
+      if (loggedNodes.indexOf(node) === -1) {
         this.log({
           message: 'unrecognized template-lint instruction: `' + instructionName + '`',
           line: node.loc && node.loc.start.line,
@@ -436,7 +454,7 @@ module.exports = function(options) {
           source: this.sourceForNode(node),
           rule: 'global'
         });
-        syntaxErrorNodes.push(node);
+        loggedNodes.push(node);
       }
     }
 

--- a/test/helpers/rule-test-harness.js
+++ b/test/helpers/rule-test-harness.js
@@ -8,8 +8,8 @@ var assign = require('lodash').assign;
 module.exports = function(options) {
   var groupingMethod = options.focus ? describe.only : describe;
   groupingMethod(options.name, function() {
-    var DISABLE_ALL = '<!-- template-lint disable=true -->';
-    var DISABLE_ONE = '<!-- template-lint ' + options.name + '=false -->';
+    var DISABLE_ALL = '{{! template-lint-disable }}';
+    var DISABLE_ONE = '{{! template-lint-disable ' + options.name + ' }}';
 
     var linter, config;
 

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -4,89 +4,611 @@ var assert = require('power-assert');
 var _precompile = require('glimmer-engine').precompile;
 var buildPlugin = require('./../../lib/rules/base');
 
-describe('base plugin tests', function() {
-  var messages, config;
-
-  function plugin() {
-    var FakePlugin = buildPlugin({
-      log: function(result) {
-        messages.push(result.source);
-      },
-      name: 'fake',
-      config: config
-    });
-
-    FakePlugin.prototype.visitors = function() {
-      return {
-        ElementNode: function(node) {
-          this.process(node);
-        },
-
-        TextNode: function(node) {
-          if (!node.loc) { return; }
-
-          this.process(node);
-        }
-      };
-    };
-
-    FakePlugin.prototype.process = function(node) {
-      this.log({
-        message: 'Node source',
-        line: node.loc && node.loc.start.line,
-        column: node.loc && node.loc.start.column,
-        source: this.sourceForNode(node)
-      });
-    };
-
-    return FakePlugin;
-  }
-
-  function precompile(template) {
+describe('base plugin', function() {
+  function precompileTemplate(template, ast) {
     _precompile(template, {
       rawSource: template,
       moduleName: 'layout.hbs',
       plugins: {
-        ast: [
-          plugin()
-        ]
+        ast: ast
       }
     });
   }
 
-  beforeEach(function() {
-    messages = [];
-    config   = {};
-  });
+  describe('parses templates', function() {
+    var messages, config;
 
-  function expectSource(config) {
-    var template = config.template;
-    var nodeSources = config.sources;
+    function plugin() {
+      var FakePlugin = buildPlugin({
+        log: function(result) {
+          messages.push(result.source);
+        },
+        name: 'fake',
+        config: config
+      });
 
-    it('can get raw source for `' + template + '`', function() {
-      precompile(template);
+      FakePlugin.prototype.visitors = function() {
+        return {
+          ElementNode: function(node) {
+            this.process(node);
+          },
 
-      assert.deepEqual(messages, nodeSources);
+          TextNode: function(node) {
+            if (!node.loc) {
+              return;
+            }
+
+            this.process(node);
+          }
+        };
+      };
+
+      FakePlugin.prototype.process = function(node) {
+        this.log({
+          message: 'Node source',
+          line: node.loc && node.loc.start.line,
+          column: node.loc && node.loc.start.column,
+          source: this.sourceForNode(node)
+        });
+      };
+
+      return FakePlugin;
+    }
+
+    function precompile(template) {
+      precompileTemplate(template, [ plugin() ]);
+    }
+
+    beforeEach(function() {
+      messages = [];
+      config = {};
     });
-  }
 
-  expectSource({
-    template: '<div>Foo</div>',
-    sources: [
-      '<div>Foo</div>',
-      'Foo'
-    ]
+    function expectSource(config) {
+      var template = config.template;
+      var nodeSources = config.sources;
+
+      it('can get raw source for `' + template + '`', function() {
+        precompile(template);
+
+        assert.deepEqual(messages, nodeSources);
+      });
+    }
+
+    expectSource({
+      template: '<div>Foo</div>',
+      sources: [
+        '<div>Foo</div>',
+        'Foo'
+      ]
+    });
+
+    expectSource({
+      template: '<div>\n  <div data-foo="blerp">\n    Wheee!\n  </div>\n</div>',
+      sources: [
+        '<div>\n  <div data-foo="blerp">\n    Wheee!\n  </div>\n</div>',
+        '\n  ',
+        '<div data-foo="blerp">\n    Wheee!\n  </div>',
+        '"blerp"',
+        '\n    Wheee!\n  ',
+        '\n'
+      ]
+    });
   });
 
-  expectSource({
-    template: '<div>\n  <div data-foo="blerp">\n    Wheee!\n  </div>\n</div>',
-    sources: [
-      '<div>\n  <div data-foo="blerp">\n    Wheee!\n  </div>\n</div>',
-      '\n  ',
-      '<div data-foo="blerp">\n    Wheee!\n  </div>',
-      '"blerp"',
-      '\n    Wheee!\n  ',
-      '\n'
-    ]
+  describe('parses instructions', function() {
+    var config;
+
+    function plugin() {
+      var FakePlugin = buildPlugin({
+        name: 'fake',
+        config: true
+      });
+
+      FakePlugin.prototype.visitors = function() {
+        return {
+          MustacheCommentStatement: function(node) {
+            this.process(node);
+          }
+        };
+      };
+
+      FakePlugin.prototype.process = function(node) {
+        config = this._processInstructionNode(node);
+      };
+
+      return FakePlugin;
+    }
+
+    function precompile(template) {
+      precompileTemplate(template, [ plugin() ]);
+    }
+
+    beforeEach(function() {
+      config = null;
+    });
+
+    function expectConfig(instruction, expectedConfig) {
+      it('can parse `' + instruction + '`', function() {
+        precompile('{{! ' + instruction + ' }}');
+        assert.deepEqual(config, expectedConfig);
+      });
+    }
+
+    // Global enable/disable
+    expectConfig('template-lint-disable', { value: false, tree: false });
+    expectConfig('template-lint-disable-tree', { value: false, tree: true });
+    expectConfig('template-lint-enable', { value: true, tree: false });
+    expectConfig('template-lint-enable-tree', { value: true, tree: true });
+    expectConfig('  template-lint-enable-tree ', { value: true, tree: true });
+
+    // Specific enable/disable
+    expectConfig('template-lint-disable fake', { value: false, tree: false });
+    expectConfig('template-lint-disable-tree fake', { value: false, tree: true });
+    expectConfig('template-lint-disable fake foobar', { value: false, tree: false });
+    expectConfig('template-lint-disable foobar fake barfoo', { value: false, tree: false });
+    expectConfig('template-lint-disable foobar', null);
+    expectConfig(' template-lint-disable   fake ', { value: false, tree: false });
+    expectConfig('template-lint-disable   foobar    fake   barfoo ', { value: false, tree: false });
+
+    // Configure
+    expectConfig('template-lint-configure fake { "key1": "value", "key2": { "key3": 1 } }', {
+      value: { key1: 'value', key2: { key3: 1 } },
+      tree: false
+    });
+    expectConfig('template-lint-configure-tree fake { "key": "value" }', {
+      value: { key: 'value' },
+      tree: true
+    });
+    expectConfig('template-lint-configure-tree fake true', {
+      value: true,
+      tree: true
+    });
+    expectConfig('template-lint-configure-tree fake false', {
+      value: false,
+      tree: true
+    });
+    expectConfig('template-lint-configure-tree foobar { "key": "value" }', null);
+    expectConfig('  template-lint-configure-tree    fake   { "key": "value" }', {
+      value: { key: 'value' },
+      tree: true
+    });
+
+    // Not config
+    expectConfig('this code is awesome', null);
+    expectConfig('template-lint', null);
+    expectConfig('template-lint-', null);
+  });
+
+  describe('scopes instructions', function() {
+    var events;
+
+    function getId(node) {
+      if (node.attributes) {
+        for (var i = 0; i < node.attributes.length; i++) {
+          if (node.attributes[i].name === 'id') {
+            return node.attributes[i].value.chars;
+          }
+        }
+      }
+      return '';
+    }
+
+    function addEvent(event, node, plugin) {
+      events.push([ event, getId(node), plugin.config ]);
+    }
+
+    function plugin() {
+      var FakePlugin = buildPlugin({
+        name: 'fake',
+        config: true
+      });
+
+      FakePlugin.prototype.visitors = function() {
+        var pluginContext = this;
+
+        return {
+          ElementNode: {
+            enter: function(node) {
+              addEvent('element/enter', node, pluginContext);
+            },
+            exit: function(node) {
+              addEvent('element/exit', node, pluginContext);
+            },
+            keys: {
+              children: {
+                enter: function(node) {
+                  addEvent('element/enter:children', node, pluginContext);
+                },
+                exit: function(node) {
+                  addEvent('element/exit:children', node, pluginContext);
+                }
+              }
+            }
+          },
+          MustacheCommentStatement: {
+            enter: function(node) {
+              addEvent('comment/enter', node, pluginContext);
+            },
+            exit: function(node) {
+              addEvent('comment/exit', node, pluginContext);
+            }
+          }
+        };
+      };
+
+      return FakePlugin;
+    }
+
+    function precompile(template) {
+      precompileTemplate(template, [ plugin() ]);
+    }
+
+    beforeEach(function() {
+      events = [];
+    });
+
+    function expectEvents(data) {
+      var description = data.desc;
+      var template = data.template;
+      var expectedEvents = data.events;
+
+      it(description, function() {
+        precompile(template);
+        assert.deepEqual(events, expectedEvents);
+      });
+    }
+
+    expectEvents({
+      desc: 'handles top-level instructions',
+      template: [
+        '{{! template-lint-configure fake "foo" }}',
+        '<div id="id1"></div>'
+      ].join('\n'),
+      events: [
+        [ 'comment/enter',          '',    true  ],
+        [ 'comment/exit',           '',    'foo' ],
+        [ 'element/enter',          'id1', 'foo' ],
+        [ 'element/enter:children', 'id1', 'foo' ],
+        [ 'element/exit:children',  'id1', 'foo' ],
+        [ 'element/exit',           'id1', 'foo' ]
+      ]
+    });
+
+    expectEvents({
+      desc: 'handles element-child instructions',
+      template: [
+        '<div id="id1">',
+        '  {{! template-lint-configure fake "foo" }}',
+        '  <span id="id2"></span>',
+        '</div>',
+        '<i id="id3"></i>'
+      ].join('\n'),
+      events: [
+        [ 'element/enter',          'id1', true  ],
+        [ 'element/enter:children', 'id1', true  ],
+        [ 'comment/enter',          '',    true  ],
+        [ 'comment/exit',           '',    'foo' ],
+        [ 'element/enter',          'id2', 'foo' ],
+        [ 'element/enter:children', 'id2', 'foo' ],
+        [ 'element/exit:children',  'id2', 'foo' ],
+        [ 'element/exit',           'id2', 'foo' ],
+        [ 'element/exit:children',  'id1', true  ],
+        [ 'element/exit',           'id1', true  ],
+        [ 'element/enter',          'id3', true  ],
+        [ 'element/enter:children', 'id3', true  ],
+        [ 'element/exit:children',  'id3', true  ],
+        [ 'element/exit',           'id3', true  ]
+      ]
+    });
+
+    expectEvents({
+      desc: 'handles niece/nephew instructions',
+      template: [
+        '<div id="id1">',
+        '  {{! template-lint-configure fake "foo" }}',
+        '  <span id="id2">',
+        '    {{! template-lint-configure fake "bar" }}',
+        '    <b id="id3"/>',
+        '  </span>',
+        '</div>',
+        '<i id="id4"></i>'
+      ].join('\n'),
+      events: [
+        [ 'element/enter',          'id1', true  ],
+        [ 'element/enter:children', 'id1', true  ],
+        [ 'comment/enter',          '',    true  ],
+        [ 'comment/exit',           '',    'foo' ],
+        [ 'element/enter',          'id2', 'foo' ],
+        [ 'element/enter:children', 'id2', 'foo' ],
+        [ 'comment/enter',          '',    'foo' ],
+        [ 'comment/exit',           '',    'bar' ],
+        [ 'element/enter',          'id3', 'bar' ],
+        [ 'element/enter:children', 'id3', 'bar' ],
+        [ 'element/exit:children',  'id3', 'bar' ],
+        [ 'element/exit',           'id3', 'bar' ],
+        [ 'element/exit:children',  'id2', 'foo' ],
+        [ 'element/exit',           'id2', 'foo' ],
+        [ 'element/exit:children',  'id1', true  ],
+        [ 'element/exit',           'id1', true  ],
+        [ 'element/enter',          'id4', true  ],
+        [ 'element/enter:children', 'id4', true  ],
+        [ 'element/exit:children',  'id4', true  ],
+        [ 'element/exit',           'id4', true  ]
+      ]
+    });
+
+    expectEvents({
+      desc: 'handles sibling instructions',
+      template: [
+        '<div id="id1">',
+        '  {{! template-lint-configure fake "foo" }}',
+        '  <span id="id2"/>',
+        '  {{! template-lint-configure fake "bar" }}',
+        '  <b id="id3"/>',
+        '</div>',
+        '<i id="id4"></i>'
+      ].join('\n'),
+      events: [
+        [ 'element/enter',          'id1', true  ],
+        [ 'element/enter:children', 'id1', true  ],
+        [ 'comment/enter',          '',    true  ],
+        [ 'comment/exit',           '',    'foo' ],
+        [ 'element/enter',          'id2', 'foo' ],
+        [ 'element/enter:children', 'id2', 'foo' ],
+        [ 'element/exit:children',  'id2', 'foo' ],
+        [ 'element/exit',           'id2', 'foo' ],
+        [ 'comment/enter',          '',    'foo' ],
+        [ 'comment/exit',           '',    'bar' ],
+        [ 'element/enter',          'id3', 'bar' ],
+        [ 'element/enter:children', 'id3', 'bar' ],
+        [ 'element/exit:children',  'id3', 'bar' ],
+        [ 'element/exit',           'id3', 'bar' ],
+        [ 'element/exit:children',  'id1', true  ],
+        [ 'element/exit',           'id1', true  ],
+        [ 'element/enter',          'id4', true  ],
+        [ 'element/enter:children', 'id4', true  ],
+        [ 'element/exit:children',  'id4', true  ],
+        [ 'element/exit',           'id4', true  ]
+      ]
+    });
+
+    expectEvents({
+      desc: 'handles in-element instructions',
+      template: [
+        '<div id="id1">',
+        '  <span id="id2" {{! template-lint-configure fake "foo" }}>',
+        '    <i id="id3">',
+        '      <b id="id4"/>',
+        '    </i>',
+        '  </span>',
+        '</div>'
+      ].join('\n'),
+      events: [
+        [ 'element/enter',          'id1', true  ],
+        [ 'element/enter:children', 'id1', true  ],
+        [ 'element/enter',          'id2', 'foo' ],
+        [ 'element/enter:children', 'id2', true  ],
+        [ 'element/enter',          'id3', true  ],
+        [ 'element/enter:children', 'id3', true  ],
+        [ 'element/enter',          'id4', true  ],
+        [ 'element/enter:children', 'id4', true  ],
+        [ 'element/exit:children',  'id4', true  ],
+        [ 'element/exit',           'id4', true  ],
+        [ 'element/exit:children',  'id3', true  ],
+        [ 'element/exit',           'id3', true  ],
+        [ 'element/exit:children',  'id2', true  ],
+        [ 'comment/enter',          '',    'foo' ],
+        [ 'comment/exit',           '',    'foo' ],
+        [ 'element/exit',           'id2', 'foo' ],
+        [ 'element/exit:children',  'id1', true  ],
+        [ 'element/exit',           'id1', true  ]
+      ]
+    });
+
+    expectEvents({
+      desc: 'handles in-element tree instructions',
+      template: [
+        '<div id="id1">',
+        '  <span id="id2" {{! template-lint-configure-tree fake "foo" }}>',
+        '    <i id="id3">',
+        '      <b id="id4"/>',
+        '    </i>',
+        '  </span>',
+        '</div>'
+      ].join('\n'),
+      events: [
+        [ 'element/enter',          'id1', true  ],
+        [ 'element/enter:children', 'id1', true  ],
+        [ 'element/enter',          'id2', 'foo' ],
+        [ 'element/enter:children', 'id2', 'foo' ],
+        [ 'element/enter',          'id3', 'foo' ],
+        [ 'element/enter:children', 'id3', 'foo' ],
+        [ 'element/enter',          'id4', 'foo' ],
+        [ 'element/enter:children', 'id4', 'foo' ],
+        [ 'element/exit:children',  'id4', 'foo' ],
+        [ 'element/exit',           'id4', 'foo' ],
+        [ 'element/exit:children',  'id3', 'foo' ],
+        [ 'element/exit',           'id3', 'foo' ],
+        [ 'element/exit:children',  'id2', 'foo' ],
+        [ 'comment/enter',          '',    'foo' ],
+        [ 'comment/exit',           '',    'foo' ],
+        [ 'element/exit',           'id2', 'foo' ],
+        [ 'element/exit:children',  'id1', true  ],
+        [ 'element/exit',           'id1', true  ]
+      ]
+    });
+
+    expectEvents({
+      desc: 'handles in-element instruction in descendant of in-element tree instruction',
+      template: [
+        '<div id="id1" {{! template-lint-configure-tree fake "foo" }}>',
+        '  <span id="id2">',
+        '    <i id="id3" {{! template-lint-configure fake "bar" }}>',
+        '      <b id="id4"/>',
+        '    </i>',
+        '  </span>',
+        '</div>'
+      ].join('\n'),
+      events: [
+        [ 'element/enter',          'id1', 'foo' ],
+        [ 'element/enter:children', 'id1', 'foo' ],
+        [ 'element/enter',          'id2', 'foo' ],
+        [ 'element/enter:children', 'id2', 'foo' ],
+        [ 'element/enter',          'id3', 'bar' ],
+        [ 'element/enter:children', 'id3', 'foo' ],
+        [ 'element/enter',          'id4', 'foo' ],
+        [ 'element/enter:children', 'id4', 'foo' ],
+        [ 'element/exit:children',  'id4', 'foo' ],
+        [ 'element/exit',           'id4', 'foo' ],
+        [ 'element/exit:children',  'id3', 'foo' ],
+        [ 'comment/enter',          '',    'bar' ],
+        [ 'comment/exit',           '',    'bar' ],
+        [ 'element/exit',           'id3', 'bar' ],
+        [ 'element/exit:children',  'id2', 'foo' ],
+        [ 'element/exit',           'id2', 'foo' ],
+        [ 'element/exit:children',  'id1', 'foo' ],
+        [ 'comment/enter',          '',    'foo' ],
+        [ 'comment/exit',           '',    'foo' ],
+        [ 'element/exit',           'id1', 'foo' ]
+      ]
+    });
+
+    expectEvents({
+      desc: 'handles in-element tree instruction in descendant of in-element tree instruction',
+      template: [
+        '<div id="id1" {{! template-lint-configure-tree fake "foo" }}>',
+        '  <span id="id2">',
+        '    <i id="id3" {{! template-lint-configure-tree fake "bar" }}>',
+        '      <b id="id4"/>',
+        '    </i>',
+        '  </span>',
+        '</div>'
+      ].join('\n'),
+      events: [
+        [ 'element/enter',          'id1', 'foo' ],
+        [ 'element/enter:children', 'id1', 'foo' ],
+        [ 'element/enter',          'id2', 'foo' ],
+        [ 'element/enter:children', 'id2', 'foo' ],
+        [ 'element/enter',          'id3', 'bar' ],
+        [ 'element/enter:children', 'id3', 'bar' ],
+        [ 'element/enter',          'id4', 'bar' ],
+        [ 'element/enter:children', 'id4', 'bar' ],
+        [ 'element/exit:children',  'id4', 'bar' ],
+        [ 'element/exit',           'id4', 'bar' ],
+        [ 'element/exit:children',  'id3', 'bar' ],
+        [ 'comment/enter',          '',    'bar' ],
+        [ 'comment/exit',           '',    'bar' ],
+        [ 'element/exit',           'id3', 'bar' ],
+        [ 'element/exit:children',  'id2', 'foo' ],
+        [ 'element/exit',           'id2', 'foo' ],
+        [ 'element/exit:children',  'id1', 'foo' ],
+        [ 'comment/enter',          '',    'foo' ],
+        [ 'comment/exit',           '',    'foo' ],
+        [ 'element/exit',           'id1', 'foo' ]
+      ]
+    });
+
+    expectEvents({
+      desc: 'handles descendant instruction of in-element tree instruction',
+      template: [
+        '<div id="id1" {{! template-lint-configure-tree fake "foo" }}>',
+        '  <span id="id2">',
+        '    {{! template-lint-configure fake "bar" }}',
+        '    <i id="id3">',
+        '      <b id="id4"/>',
+        '    </i>',
+        '  </span>',
+        '</div>'
+      ].join('\n'),
+      events: [
+        [ 'element/enter',          'id1', 'foo' ],
+        [ 'element/enter:children', 'id1', 'foo' ],
+        [ 'element/enter',          'id2', 'foo' ],
+        [ 'element/enter:children', 'id2', 'foo' ],
+        [ 'comment/enter',          '',    'foo' ],
+        [ 'comment/exit',           '',    'bar' ],
+        [ 'element/enter',          'id3', 'bar' ],
+        [ 'element/enter:children', 'id3', 'bar' ],
+        [ 'element/enter',          'id4', 'bar' ],
+        [ 'element/enter:children', 'id4', 'bar' ],
+        [ 'element/exit:children',  'id4', 'bar' ],
+        [ 'element/exit',           'id4', 'bar' ],
+        [ 'element/exit:children',  'id3', 'bar' ],
+        [ 'element/exit',           'id3', 'bar' ],
+        [ 'element/exit:children',  'id2', 'foo' ],
+        [ 'element/exit',           'id2', 'foo' ],
+        [ 'element/exit:children',  'id1', 'foo' ],
+        [ 'comment/enter',          '',    'foo' ],
+        [ 'comment/exit',           '',    'foo' ],
+        [ 'element/exit',           'id1', 'foo' ]
+      ]
+    });
+
+    // Not really a case that makes sense, but just to be sure it doesn't mess
+    // up the config stack
+    expectEvents({
+      desc: 'ensures this pretty silly case doesn\'t mess up the config stack',
+      template: [
+        '<div id="id1">',
+        '  <span id="id2" {{! template-lint-configure fake "bar" }} {{! template-lint-configure fake "foo" }}>',
+        '    <i id="id3">',
+        '      <b id="id4"/>',
+        '    </i>',
+        '  </span>',
+        '</div>'
+      ].join('\n'),
+      events: [
+        [ 'element/enter',          'id1', true  ],
+        [ 'element/enter:children', 'id1', true  ],
+        [ 'element/enter',          'id2', 'foo' ],
+        [ 'element/enter:children', 'id2', true  ],
+        [ 'element/enter',          'id3', true  ],
+        [ 'element/enter:children', 'id3', true  ],
+        [ 'element/enter',          'id4', true  ],
+        [ 'element/enter:children', 'id4', true  ],
+        [ 'element/exit:children',  'id4', true  ],
+        [ 'element/exit',           'id4', true  ],
+        [ 'element/exit:children',  'id3', true  ],
+        [ 'element/exit',           'id3', true  ],
+        [ 'element/exit:children',  'id2', true  ],
+        [ 'comment/enter',          '',    'foo' ],
+        [ 'comment/exit',           '',    'foo' ],
+        [ 'comment/enter',          '',    'foo' ],
+        [ 'comment/exit',           '',    'foo' ],
+        [ 'element/exit',           'id2', 'foo' ],
+        [ 'element/exit:children',  'id1', true  ],
+        [ 'element/exit',           'id1', true  ]
+      ]
+    });
+
+    expectEvents({
+      desc: 'it doesn\'t call a disabled rule\'s visitor handlers',
+      template: [
+        '<div id="id1">',
+        '  <span id="id2" {{! template-lint-disable fake }}>',
+        '    <i id="id3">',
+        '      <b id="id4"/>',
+        '    </i>',
+        '  </span>',
+        '</div>'
+      ].join('\n'),
+      events: [
+        [ 'element/enter',          'id1', true  ],
+        [ 'element/enter:children', 'id1', true  ],
+        [ 'element/enter:children', 'id2', true  ],
+        [ 'element/enter',          'id3', true  ],
+        [ 'element/enter:children', 'id3', true  ],
+        [ 'element/enter',          'id4', true  ],
+        [ 'element/enter:children', 'id4', true  ],
+        [ 'element/exit:children',  'id4', true  ],
+        [ 'element/exit',           'id4', true  ],
+        [ 'element/exit:children',  'id3', true  ],
+        [ 'element/exit',           'id3', true  ],
+        [ 'element/exit:children',  'id2', true  ],
+        [ 'element/exit:children',  'id1', true  ],
+        [ 'element/exit',           'id1', true  ]
+      ]
+    });
   });
 });

--- a/test/unit/rules/lint-bare-strings-test.js
+++ b/test/unit/rules/lint-bare-strings-test.js
@@ -28,8 +28,8 @@ generateRuleTests({
     '{{t "foo"}}',
     '{{t "foo"}}, {{t "bar"}} ({{length}})',
     '(),.&+-=*/#%!?:[]{}',
-    '<!-- template-lint bare-strings=false -->',
-    '<!-- template-lint enabled=false -->',
+    '{{! template-lint-disable bare-strings }}',
+    '{{! template-lint-disable }}',
 
     // placeholder is a <input> specific attribute
     '<div placeholder="wat?"></div>',

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -151,8 +151,8 @@ generateRuleTests({
         '\t<p>Hi!</p>\n' +
         '</div>'
     },
-    '<!-- template-lint bare-strings=false -->',
-    '<!-- template-lint enabled=false -->',
+    '{{! template-lint-disable bare-strings }}',
+    '{{! template-lint-disable }}',
     {
       template: [
         '<div>',

--- a/test/unit/rules/lint-html-comments-test.js
+++ b/test/unit/rules/lint-html-comments-test.js
@@ -10,8 +10,8 @@ generateRuleTests({
   good: [
     '{{!-- comment here --}}',
     '{{!--comment here--}}',
-    '<!-- template-lint bare-strings=false -->',
-    '<!-- template-lint enabled=false -->'
+    '{{! template-lint-disable bare-strings }}',
+    '{{! template-lint-disable }}'
   ],
 
   bad: [

--- a/test/unit/rules/lint-triple-curlies-test.js
+++ b/test/unit/rules/lint-triple-curlies-test.js
@@ -9,8 +9,8 @@ generateRuleTests({
 
   good: [
     '{{foo}}',
-    '<!-- template-lint bare-strings=false -->',
-    '<!-- template-lint enabled=false -->'
+    '{{! template-lint-disable bare-strings }}',
+    '{{! template-lint-disable }}'
   ],
 
   bad: [


### PR DESCRIPTION
Fixes #79.

This implements a new way of providing in-template instructions for configuring the rules. Rather than using HTML comments that modify a rule for the rest of the file, we can now use handlebars comments to modify a rule in some DOM-related scope.

This also allows full inline rule configuration rather than just enabling/disabling since it's easy to embed JSON strings inside handlebars comments.

I ended up solving the recursive/non-recursive issue in a fairly blunt, but I think effective way. It's pretty simple -- if we think of instructions as having names and arguments, then the name plus where the comment appears in the DOM tells you what the scope of the instruction is, and the arguments tell you what rules it affects and how. So it's all pretty much like we discussed in #79, except you can append `-tree` to the instruction name to make it recursive:

```handlebars
<div {{! template-lint-disable "my-rule" }}>
  {{! my-rule *not* disabled }}
</div>
<div {{! template-lint-disable-tree "my-rule" }}>
  {{! my-rule *is* disabled }}
</div>
```

and similarly for `template-lint-enable` and `template-lint-configure`.

Still TODO:

- [x] Deprecate old-style HTML comment instructions
- [x] Update unit tests to use new-style comment instructions
- [x] Update README