### PR TITLE
Enable empty alt attributes for img-alt-attributes test

### DIFF
--- a/lib/rules/lint-img-alt-attributes.js
+++ b/lib/rules/lint-img-alt-attributes.js
@@ -49,13 +49,5 @@ module.exports = function(addonContext) {
 function isAltPresent(node) {
   var altAttribute = AstNodeInfo.findAttribute(node, 'alt');
 
-  if (!altAttribute) { return false; }
-
-  switch (altAttribute.value.type) {
-  case 'TextNode':
-    return altAttribute.value.chars.length > 0;
-  case 'ConcatStatement':
-  case 'MustacheStatement':
-    return true;
-  }
+  return !!altAttribute;
 }

--- a/test/unit/rules/lint-img-alt-attributes-test.js
+++ b/test/unit/rules/lint-img-alt-attributes-test.js
@@ -11,7 +11,9 @@ generateRuleTests({
     '<img alt="hullo">',
     '<img alt={{foo}}>',
     '<img alt="blah {{derp}}">',
-    '<img aria-hidden="true">'
+    '<img aria-hidden="true">',
+    '<img alt="">',
+    '<img alt>'
   ],
 
   bad: [
@@ -23,30 +25,6 @@ generateRuleTests({
         message: 'img tags must have an alt attribute',
         moduleId: 'layout.hbs',
         source: '<img>',
-        line: 1,
-        column: 0
-      }
-    },
-    {
-      template: '<img alt>',
-
-      result: {
-        rule: 'img-alt-attributes',
-        message: 'img tags must have an alt attribute',
-        moduleId: 'layout.hbs',
-        source: '<img alt>',
-        line: 1,
-        column: 0
-      }
-    },
-    {
-      template: '<img alt="">',
-
-      result: {
-        rule: 'img-alt-attributes',
-        message: 'img tags must have an alt attribute',
-        moduleId: 'layout.hbs',
-        source: '<img alt="">',
         line: 1,
         column: 0
       }


### PR DESCRIPTION
See https://github.com/rwjblue/ember-cli-template-lint/issues/174

I really like the new "img-alt-attributes" rule. However, it currently also fails on e.g. `<img src='...' alt=''>`, 
which is valid. Consider this use case for icons:

```html
<a href='users.html'>
  <img src='users.png' alt=''>
  Users
</a>
```

An empty alt tag has a distinctively different semantic meaning from a missing alt tag - an image with an empty alt tag will simply be ignored by screen readers, while an image with a missing alt tag will have its file name read (or something like this). In the above use case, by adding an alt tag "users" to the icon, a screen reader would read out "Users Users", which wouldn't be helpful at all. Further information on the topic can be found here: https://www.w3.org/TR/WCAG20-TECHS/H67.html

Considering this, the rule should allow empty alt tags and only error on missing ones.