### PR TITLE
Add documentation for unused-block-parameters rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,40 @@ whereas this is allowed:
 <div style={{make-background url}}>
 ```
 
+#### unused-block-params
+
+This rule forbids unused block parameters except when they are needed to access a later parameter.
+
+Forbidden (unused parameters):
+
+```
+{{#each users as |user index|}}
+  {{user.name}}
+{{/each}}
+```
+
+Allowed (used parameters):
+
+```
+{{#each users as |user|}}
+  {{user.name}}
+{{/each}}
+```
+
+```
+{{#each users as |user index|}}
+  {{index}} {{user.name}}
+{{/each}}
+```
+
+Allowed (later parameter used):
+
+```
+{{#each users as |user index|}}
+  {{index}}
+{{/each}}
+```
+
 ### Deprecations
 
 #### deprecated-each-syntax

--- a/lib/rules/lint-unused-block-params.js
+++ b/lib/rules/lint-unused-block-params.js
@@ -1,5 +1,45 @@
 'use strict';
 
+/*
+ Disallows unused block params
+
+  Good:
+
+  ```
+  {{#each users as |user|}}
+    {{user.name}}
+  {{/each}}
+  ```
+
+  Good:
+
+  ```
+  {{#each users as |user index|}}
+    {{index}} {{user.name}}
+  {{/each}}
+  ```
+
+  Good:
+
+  ```
+  {{#each users as |user index|}}
+    {{index}}
+  {{/each}}
+  ```
+
+  Bad:
+
+  ```
+  {{#each users as |user index|}}
+    {{user.name}}
+  {{/each}}
+  ```
+
+  The following values are valid configuration:
+
+    * boolean -- `true` for enabled / `false` for disabled
+*/
+
 var buildPlugin = require('./base');
 
 module.exports = function(addonContext) {


### PR DESCRIPTION
Adds documentation for the `unused-block-params` rule.
Fixes #142 