### PR TITLE
Added CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ var results = linter.verify(template);
 * `source` - The source that caused the error.
 * `fix` - An object describing how to fix the error.
 
+It is also possible to run linter via CLI.
+```
+./node_modules/ember-template-lint/bin/lint
+```
+
+By default script finds template files in directory: app/templates, but you can adjust it using option:
+* -d, --dir [templatesDir] templates directory (default: app/templates)
+
 ## Configuration
 
 ### Project Wide
@@ -397,7 +405,7 @@ The block form is a little longer but has advantages over the inline form:
 This rule is configured with one boolean value:
 
   * boolean -- `true` for enabled / `false` for disabled
-  
+
 #### inline-styles
 
 Inline styles are not the best practice because they are hard to maintain and usually make the overall size of the project bigger. This rule forbids the inline styles.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ It is also possible to run linter via CLI.
 ./node_modules/ember-template-lint/bin/lint
 ```
 
-By default script finds template files in directory: app/templates, but you can adjust it using option:
+By default script finds template files in directory: app/templates, but it's possible to adjust it using option:
 * -d, --dir [templatesDir] templates directory (default: app/templates)
 
 ## Configuration

--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+'use strict';
+
+const linter = require('../lib/lint-dir.js');
+const options = require('cli').parse({
+  dir: ['d', 'templates directory', 'dir', 'app/templates']
+});
+
+linter(options);

--- a/bin/lint
+++ b/bin/lint
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-const linter = require('../lib/lint-dir.js');
-const options = require('cli').parse({
+var linter = require('../lib/lint-dir.js');
+var options = require('cli').parse({
   dir: ['d', 'templates directory', 'dir', 'app/templates']
 });
 

--- a/lib/lint-dir.js
+++ b/lib/lint-dir.js
@@ -9,12 +9,14 @@ var errors = [];
 module.exports = function(options) {
   walker(options.dir).on('file', function(filePath) {
     if (path.extname(filePath) === '.hbs') {
-      var result = linter.verify({
+      var results = linter.verify({
         moduleId: path.relative(options.dir, filePath),
         source: fs.readFileSync(filePath, { encoding: 'utf8' }),
       });
-      if (result.length > 0) {
-        errors.push(...result);
+      if (results.length > 0) {
+        results.forEach(function(result) {
+          errors.push(result);
+        });
       }
     }
   }).on('end', function() {

--- a/lib/lint-dir.js
+++ b/lib/lint-dir.js
@@ -7,7 +7,7 @@ var linter = new TemplateLinter();
 var errors = [];
 
 module.exports = function(options) {
-  walker(options.dir).on('file', (filePath) => {
+  walker(options.dir).on('file', function(filePath) {
     if (path.extname(filePath) === '.hbs') {
       var result = linter.verify({
         moduleId: path.relative(options.dir, filePath),
@@ -17,11 +17,11 @@ module.exports = function(options) {
         errors.push(...result);
       }
     }
-  }).on('end', () => {
+  }).on('end', function() {
     if (errors.length === 0) {
       return;
     }
-    errors.forEach((error) => {
+    errors.forEach(function(error) {
       console.log(`${error.rule}:`, error.message);
       console.log(`(${error.moduleId} @ L${error.line}:C${error.column}):`);
       console.log(error.source);

--- a/lib/lint-dir.js
+++ b/lib/lint-dir.js
@@ -1,15 +1,15 @@
-const fs = require('fs');
-const walker = require('walker');
-const path = require('path');
-const TemplateLinter = require('ember-template-lint');
+var fs = require('fs');
+var walker = require('walker');
+var path = require('path');
+var TemplateLinter = require('ember-template-lint');
 
-const linter = new TemplateLinter();
-const errors = [];
+var linter = new TemplateLinter();
+var errors = [];
 
 module.exports = function(options) {
   walker(options.dir).on('file', (filePath) => {
     if (path.extname(filePath) === '.hbs') {
-      const result = linter.verify({
+      var result = linter.verify({
         moduleId: path.relative(options.dir, filePath),
         source: fs.readFileSync(filePath, { encoding: 'utf8' }),
       });

--- a/lib/lint-dir.js
+++ b/lib/lint-dir.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const walker = require('walker');
+const path = require('path');
+const TemplateLinter = require('ember-template-lint');
+
+const linter = new TemplateLinter();
+const errors = [];
+
+module.exports = function(options) {
+  walker(options.dir).on('file', (filePath) => {
+    if (path.extname(filePath) === '.hbs') {
+      const result = linter.verify({
+        moduleId: path.relative(options.dir, filePath),
+        source: fs.readFileSync(filePath, { encoding: 'utf8' }),
+      });
+      if (result.length > 0) {
+        errors.push(...result);
+      }
+    }
+  }).on('end', () => {
+    if (errors.length === 0) {
+      return;
+    }
+    errors.forEach((error) => {
+      console.log(`${error.rule}:`, error.message);
+      console.log(`(${error.moduleId} @ L${error.line}:C${error.column}):`);
+      console.log(error.source);
+      if(error.fix) {
+        console.log('(FIX):');
+        console.log(error.fix.text);
+      }
+      console.log();
+    });
+    console.log(`===== ${errors.length} Template Linting Errors`);
+    process.exit(1);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
   },
   "keywords": [],
   "dependencies": {
-    "chalk": "^1.1.3",
+    "walker": "^1.0.7",
     "cli": "^1.0.1",
-    "glimmer-engine": "^0.19.1",
-    "lodash": "^4.11.1",
+    "chalk": "^1.1.3",
     "resolve": "^1.1.3",
-    "walker": "^1.0.7"
+    "glimmer-engine": "^0.19.1",
+    "lodash": "^4.11.1"
   },
   "bugs": {
     "url": "https://github.com/rwjblue/ember-template-lint/issues"

--- a/package.json
+++ b/package.json
@@ -33,9 +33,11 @@
   "keywords": [],
   "dependencies": {
     "chalk": "^1.1.3",
-    "resolve": "^1.1.3",
+    "cli": "^1.0.1",
     "glimmer-engine": "^0.19.1",
-    "lodash": "^4.11.1"
+    "lodash": "^4.11.1",
+    "resolve": "^1.1.3",
+    "walker": "^1.0.7"
   },
   "bugs": {
     "url": "https://github.com/rwjblue/ember-template-lint/issues"


### PR DESCRIPTION
It provides CLI support. By executing CLI command:
```
./node_modules/ember-template-lint/bin/lint
```
Above command finds all *.hbs files and checking them for linting errors. Output is similar to ember-cli-template-lint. It is possible to adjust searching directory by adding `-d` option.

I attached output log file which shows how this command works on real project.
[out.txt](https://github.com/rwjblue/ember-template-lint/files/644921/out.txt)

