### PR TITLE
Cannot read property 'original' of undefine

### DIFF
--- a/lib/helpers/ast-node-info.js
+++ b/lib/helpers/ast-node-info.js
@@ -16,6 +16,10 @@ function isCommentStatement(node) {
   return node.type === 'CommentStatement';
 }
 
+function isMustacheCommentStatement(node) {
+  return node.type === 'MustacheCommentStatement';
+}
+
 function isElementNode(node) {
   return node && node.type === 'ElementNode';
 }
@@ -81,6 +85,7 @@ module.exports = {
   hasChildren: hasChildren,
   isBlockStatement: isBlockStatement,
   isCommentStatement: isCommentStatement,
+  isMustacheCommentStatement: isMustacheCommentStatement,
   isComponentNode: isComponentNode,
   isConfigurationHtmlComment: isConfigurationHtmlComment,
   isElementNode: isElementNode,

--- a/lib/rules/lint-block-indentation.js
+++ b/lib/rules/lint-block-indentation.js
@@ -242,6 +242,8 @@ module.exports = function(addonContext) {
           display = child.chars;
         } else if (AstNodeInfo.isCommentStatement(child)) {
           display = '<!--' + child.value + '-->';
+        } else if (AstNodeInfo.isMustacheCommentStatement(child)) {
+          display = '{{!' + child.value + '}}';
         } else {
           display = child.path.original;
         }
@@ -339,7 +341,7 @@ module.exports = function(addonContext) {
     var charAfterEnding = source[indexOfEnding + endingToken.length];
     if (indexOfEnding !== -1 && VALID_FOLLOWING_CHARS.indexOf(charAfterEnding) === -1) {
       return false;
-    } 
+    }
 
     return indexOfEnding !== -1;
   };

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -387,11 +387,11 @@ generateRuleTests({
 
       result: {
         rule: 'block-indentation',
-        message: '',
+        message: 'Incorrect indentation for `{{! comment with incorrect indentation }}` beginning at L4:C4. Expected `{{! comment with incorrect indentation }}` to be at an indentation of 2 but was found at 4.',
         moduleId: 'layout.hbs',
-        source: '',
-        line: 2,
-        column: 2
+        source: '<div>\n  {{#if foo}}\n  {{/if}}\n    {{! comment with incorrect indentation }}\n</div>',
+        line: 4,
+        column: 4
       }
     }
   ]

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -374,6 +374,25 @@ generateRuleTests({
         line: 2,
         column: 2
       }
+    },
+
+    {
+      template: [
+        '<div>',
+        '  {{#if foo}}',
+        '  {{/if}}',
+        '    {{! comment with incorrect indentation }}',
+        '</div>'
+      ].join('\n'),
+
+      result: {
+        rule: 'block-indentation',
+        message: '',
+        moduleId: 'layout.hbs',
+        source: '',
+        line: 2,
+        column: 2
+      }
     }
   ]
 });


### PR DESCRIPTION
In this very special case the linter run fails with following exception:

```
TypeError: Cannot read property 'original' of undefined
    at BasePlugin.BlockIndentation.validateBlockChildren (/Users/michal/PuppetLabs/ember-template-lint/lib/rules/lint-block-indentation.js:249:31)
    at BasePlugin.BlockIndentation.process (/Users/michal/PuppetLabs/ember-template-lint/lib/rules/lint-block-indentation.js:118:10)
    at BasePlugin.ElementNode (/Users/michal/PuppetLabs/ember-template-lint/lib/rules/lint-block-indentation.js:109:14)
    at /Users/michal/PuppetLabs/ember-template-lint/lib/rules/base.js:290:21
    at visitNode (glimmer-syntax/lib/traversal/traverse.ts:13:28)
    at visitArray (glimmer-syntax/lib/traversal/traverse.ts:74:18)
    at visitKey (glimmer-syntax/lib/traversal/traverse.ts:56:5)
    at visitNode (glimmer-syntax/lib/traversal/traverse.ts:30:7)
    at Object.traverse (glimmer-syntax/lib/traversal/traverse.ts:113:3)
    at BasePlugin.transform (/Users/michal/PuppetLabs/ember-template-lint/lib/rules/base.js:76:17)
    at Object.preprocess (glimmer-syntax/lib/parser.ts:32:25)
    at precompile (glimmer-compiler/lib/compiler.ts:63:13)
    at Linter.verify (/Users/michal/PuppetLabs/ember-template-lint/lib/index.js:95:7)
    at verify (test/helpers/rule-test-harness.js:18:21)
    at Context.<anonymous> (test/helpers/rule-test-harness.js:59:22)
    at callFn (/Users/michal/PuppetLabs/ember-template-lint/node_modules/mocha/lib/runnable.js:345:21)
    at Test.Runnable.run (/Users/michal/PuppetLabs/ember-template-lint/node_modules/mocha/lib/runnable.js:337:7)
    at Runner.runTest (/Users/michal/PuppetLabs/ember-template-lint/node_modules/mocha/lib/runner.js:444:10)
    at /Users/michal/PuppetLabs/ember-template-lint/node_modules/mocha/lib/runner.js:550:12
    at next (/Users/michal/PuppetLabs/ember-template-lint/node_modules/mocha/lib/runner.js:361:14)
    at /Users/michal/PuppetLabs/ember-template-lint/node_modules/mocha/lib/runner.js:371:7
    at next (/Users/michal/PuppetLabs/ember-template-lint/node_modules/mocha/lib/runner.js:295:14)
    at /Users/michal/PuppetLabs/ember-template-lint/node_modules/mocha/lib/runner.js:334:7
    at done (/Users/michal/PuppetLabs/ember-template-lint/node_modules/mocha/lib/runnable.js:295:5)
    at callFn (/Users/michal/PuppetLabs/ember-template-lint/node_modules/mocha/lib/runnable.js:363:7)
    at Hook.Runnable.run (/Users/michal/PuppetLabs/ember-template-lint/node_modules/mocha/lib/runnable.js:337:7)
    at next (/Users/michal/PuppetLabs/ember-template-lint/node_modules/mocha/lib/runner.js:309:10)
    at Immediate.<anonymous> (/Users/michal/PuppetLabs/ember-template-lint/node_modules/mocha/lib/runner.js:339:5)
    at runCallback (timers.js:649:20)
    at tryOnImmediate (timers.js:622:5)
    at processImmediate [as _immediateCallback] (timers.js:594:5
```

Conditions observed:
 - The problem seems to be badly indented comment after `if` or `unless` (any pair?) statement
 - The code has to be nested in some other element - `div` in my example
