### PR TITLE
Add tests for 'else if' with whitespace eaten

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "resolve": "^1.1.3",
-    "glimmer-engine": "^0.19.1",
+    "glimmer-engine": "^0.21.2",
     "lodash": "^4.11.1"
   },
   "bugs": {

--- a/test/unit/helpers/ast-node-info-test.js
+++ b/test/unit/helpers/ast-node-info-test.js
@@ -1,5 +1,5 @@
 var assert = require('power-assert');
-var preprocess = require('glimmer-engine/dist/node_modules/glimmer-syntax').preprocess;
+var preprocess = require('glimmer-engine/dist/node_modules/@glimmer/syntax').preprocess;
 var AstNodeInfo = require('../../../lib/helpers/ast-node-info');
 
 describe('isImgElement', function() {

--- a/test/unit/helpers/is-interactive-element-test.js
+++ b/test/unit/helpers/is-interactive-element-test.js
@@ -1,5 +1,5 @@
 var assert = require('power-assert');
-var preprocess = require('glimmer-engine/dist/node_modules/glimmer-syntax').preprocess;
+var preprocess = require('glimmer-engine/dist/node_modules/@glimmer/syntax').preprocess;
 var isInteractiveElement = require('../../../lib/helpers/is-interactive-element');
 
 describe('isInteractiveElement', function() {

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -130,6 +130,13 @@ generateRuleTests({
       '{{/if}}'
     ].join('\n'),
     [
+      '{{#if foo}}',
+      '  <div>do foo</div>',
+      '{{else if bar~}}',
+      '  <div>do bar</div>',
+      '{{/if}}'
+    ].join('\n'),
+    [
       '<div class="multi"',
       '     id="lines"></div>'
     ].join('\n'),
@@ -411,6 +418,25 @@ generateRuleTests({
         source: '{{#if isMorning}}  Good morning\n{{else if isAfternoon}}\n  Good afternoon\n{{else}}\n  Good night\n{{/if}}',
         line: 1,
         column: 17
+      }
+    },
+  
+    {
+      template: [
+        '{{#if isMorning}}\n' +
+        '  Good morning\n' +
+        '{{else if isAfternoon~}}\n' +
+        '    Good afternoon\n' +
+        '{{/if}}'
+      ].join('\n'),
+
+      result: {
+        rule: 'block-indentation',
+        message: 'Incorrect indentation for `Good afternoon\n` beginning at L4:C4. Expected `Good afternoon\n` to be at an indentation of 2 but was found at 4.',
+        moduleId: 'layout.hbs',
+        source: '{{else if isAfternoon~}}\n    Good afternoon\n',
+        line: 4,
+        column: 4
       }
     }
   ]


### PR DESCRIPTION
This PR adds tests for ```if-else if``` structures with whitespace eaten after ```else if``` statement.
For the tests to pass, glimmer with https://github.com/tildeio/glimmer/pull/390 is required.

Note: #163 is a prerequisite for this PR.