### PR TITLE
Add nested elseif with whitespace eaten

### DIFF
--- a/lib/rules/lint-block-indentation.js
+++ b/lib/rules/lint-block-indentation.js
@@ -313,6 +313,7 @@ module.exports = function(addonContext) {
     var elseBlockStatement = node.inverse.body[0];
 
     elseBlockStatement._startOffset = 5 + elseBlockStatement.path.original.length;
+    elseBlockStatement._isElseIfBlock = true;
   };
 
   BlockIndentation.prototype.startOffsetFor = function(node) {
@@ -320,6 +321,10 @@ module.exports = function(addonContext) {
   };
 
   BlockIndentation.prototype.shouldValidateBlockEnd = function(node) {
+    if (node._isElseIfBlock) {
+      return false;
+    }
+
     // HTML elements that start and end on the same line are fine
     if (node.loc.start.line === node.loc.end.line) {
       return false;

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -130,6 +130,14 @@ generateRuleTests({
       '{{/if}}'
     ].join('\n'),
     [
+      '{{#if foo}}',
+      '{{else if bar}}',
+      '{{else}}',
+      '  {{#if baz}}',
+      '  {{/if~}}',
+      '{{/if}}'
+    ].join('\n'),
+    [
       '<div class="multi"',
       '     id="lines"></div>'
     ].join('\n'),
@@ -354,6 +362,26 @@ generateRuleTests({
         source: '{{else}}\n',
         line: 2,
         column: 2
+      }
+    },
+
+    {
+      template: [
+        '{{#if foo}}',
+        '{{else if bar}}',
+        '{{else}}',
+        '  {{#if baz}}',
+        '  {{/if~}}',
+        '  {{/if}}'
+      ].join('\n'),
+
+      result: {
+        rule: 'block-indentation',
+        message: 'Incorrect indentation for `if` beginning at L1:C0. Expected `{{/if}}` ending at L6:C9 to be at an indentation of 0 but was found at 2.',
+        moduleId: 'layout.hbs',
+        source: '{{#if foo}}\n{{else if bar}}\n{{else}}\n  {{#if baz}}\n  {{/if~}}\n  {{/if}}',
+        line: 6,
+        column: 9
       }
     },
 


### PR DESCRIPTION
This PR fixes wrong validation of ```else if``` blocks.