### PR TITLE
Add missing syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ This rule forbids unused block parameters except when they are needed to access 
 
 Forbidden (unused parameters):
 
-```
+``` hbs
 {{#each users as |user index|}}
   {{user.name}}
 {{/each}}
@@ -452,13 +452,13 @@ Forbidden (unused parameters):
 
 Allowed (used parameters):
 
-```
+``` hbs
 {{#each users as |user|}}
   {{user.name}}
 {{/each}}
 ```
 
-```
+``` hbs
 {{#each users as |user index|}}
   {{index}} {{user.name}}
 {{/each}}
@@ -466,7 +466,7 @@ Allowed (used parameters):
 
 Allowed (later parameter used):
 
-```
+``` hbs
 {{#each users as |user index|}}
   {{index}}
 {{/each}}


### PR DESCRIPTION
Syntax highlighting was missing for the `unused-block-params` rule examples.