### PR TITLE
Loading config: fix order of extending configurations

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -176,7 +176,7 @@ function processExtends(config, options) {
 
         if (configuration.rules) {
 
-          config.rules = assign(config.rules, configuration.rules);
+          config.rules = assign(configuration.rules, config.rules);
 
         } else {
 

--- a/test/fixtures/with-plugins-overwriting/.template-lintrc.js
+++ b/test/fixtures/with-plugins-overwriting/.template-lintrc.js
@@ -4,8 +4,8 @@ module.exports = {
     './plugins/plugin2'
   ],
   extends: [
-    'plugin1:enable-inline-component',
     'plugin2:disable-inline-component',
+    'plugin1:enable-inline-component',
   ],
   rules: {
     'bare-strings': true

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -56,7 +56,7 @@ describe('get-config', function() {
 
   it('can extend and override a default configuration', function() {
     var expected = clone(recommendedConfig);
-    expected.rules['bare-strings'] = false;
+    expected.rules['bare-strings'] = true;
 
     var actual = getConfig({
       config: {


### PR DESCRIPTION
- [x] Fix `with-plugins-overwriting` fixture to have correct order of extended configurations, corresponding to expected result within acceptance spec test case (https://github.com/rwjblue/ember-template-lint/blob/master/test/acceptance-test.js#L469).
- [x] Fix clear typo/mistake in `get-config` unit test: don't try to override `bare-strings` `false` rule config value with another `false`.
- [x] `processExtends` function within `lib/get-config.js`: extend extended configurations instead of extending custom config _with_ them (:mindblown: - fixes two test cases described above).

Fixes #178 .