### PR TITLE
Document plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,18 @@ Note that enabling a rule (`{{! template-lint-enable }}`) that has been configur
 
 The following properties are allowed in the root of the `.template-lintrc.js` configuration file:
 
-* `rules` -- This is an object containing rule specific configuration (see details for each rule below).
-* `extends` -- This is a string that allows you to specify an internally curated list of rules (we suggest `recommended` here).
-* `pending` -- An array of module id's that are still pending. The goal of this array is to allow incorporating template linting
+* `rules` -- `Object`
+  This is an object containing rule specific configuration (see details for each rule below).
+* `extends` -- `string|string[]`
+  Either a string or an array of strings. Each string allows you to specify an internally curated list of rules (we suggest `recommended` here).
+* `pending` -- `string[]`
+  An array of module id's that are still pending. The goal of this array is to allow incorporating template linting
   into an existing project, without changing every single template file. You can add all existing templates to this `pending` listing
   and slowly work through them, while at the same time ensuring that new templates added to the project pass all defined rules.
-* `ignore` -- An array of module id's that are to be completely ignored.
+* `ignore` -- `string[]`
+  An array of module id's that are to be completely ignored.
+* `plugins` -- `(string|Object)[]`
+  An array of plugin objects, or strings that resolve to files that export plugin objects. See [plugin documentation](docs/plugins.md) for more details.
 
 ## Rules
 
@@ -548,6 +554,10 @@ Instead, you should use:
 ```
 
 More information is available at the [Deprecation Guide](http://emberjs.com/deprecations/v1.x/#toc_ember-view).
+
+### Defining your own rules
+
+You can define and use your own custom rules using the plugin system. See [plugin documentation](docs/plugins.md) for more details.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ var TemplateLinter = require('ember-template-lint');
 
 var linter = new TemplateLinter();
 var template = fs.readFileSync('some/path/to/template.hbs', { encoding: 'utf8' });
-var results = linter.verify(template);
+var results = linter.verify({ source: template, moduleId: 'template.hbs' });
 ```
 
 `results` will be an array of objects which have the following properties:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -16,7 +16,7 @@ Each plugin object can include these properties.
 
   Object that defines new rules.
   Each key represents the name of the rule that is defined.
-  Each value should be a string that represents a relative file path to the rule definition. See [Rule APIs](#rule-apis) for more detail.
+  Each value should be a Rule object. See [Rule APIs](#rule-apis) for more detail.
 
 * `configurations` -- `Object`
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,267 @@
+## Plugin Support
+
+You can customize the linter with rules that are more specific to your use case with the `ember-template-lint` plugin system.
+
+Plugins can define new rules and set up default configurations that can be extended.
+
+### Adding Plugins to Your Configuration
+
+In order to enable a plugin, you must add it to the `plugins` key in your configuration file.
+
+`plugins` accepts an array of either objects, or strings that resolve to files that export plugin objects.
+
+#### Define a plugin inline
+
+```javascript
+// .template-lintrc.js
+
+module.exports = {
+  plugins: [
+    {
+      // Define rules for this plugin. Each path should map to a plugin rule
+      rules: [
+        'disallow-inline-components': require('./lib/template-lint-rules/disallow-inline-components'),
+        'another-custom-rule': require('.lib/template-lint-rules/another-custom-rule')
+      ],
+
+      // Define configurations for this plugin that can be extended by the base configuration
+      configurations: [
+        'no-inline': {
+            rules: {
+              'disallow-inline-components': true
+            }
+        }
+      ]
+    },
+  ],
+
+  extends: [
+    // Extend configuration defined in the inline plugin
+    'no-inline'
+  ],
+
+  rules: {
+    'bare-strings': true,
+
+    // Use a rule defined in the inline plugin
+    'another-custom-rule': true
+  }
+}
+```
+
+#### Define a plugin based on a relative path
+```javascript
+// .template-lintrc.js
+
+module.exports = {
+  plugins: [
+    // Define a plugin that is exported elsewhere (i.e. a third-party plugin)
+    './plugins/some-local-plugin',
+    'some-npm-package/third-party-plugin',
+  ],
+
+  extends: [
+    'recommended',
+
+    // Extend configuration defined in plugins
+    'some-local-plugin:recommended',
+    'third-party-plugin:strict'
+  ],
+
+  rules: {
+    'bare-strings': true,
+
+    // Use a rule defined in a plugin
+    'rule-defined-in-some-local-plugin': true
+  }
+}
+
+```
+
+Each path included as part of `plugins` should resolve to a file that exports a plugin object.
+
+```javascript
+// plugins/some-local-plugin.js
+
+'use strict';
+
+module.exports = {
+
+  // Name of plugin
+  name: 'some-local-plugin',
+
+  // These rules will be added to the namespace of any config file that imports this plugin
+  rules: {
+    'inline-component': require('./rules/lint-inline-component')
+  },
+
+  // These configurations will be available to extend in any config file that imports this plugin, namespaced by the name of this plugin
+  configurations: {
+    recommended: {
+      rules: {
+        'inline-component': true,
+        'bare-strings': true
+      }
+    }
+  }
+};
+```
+
+### Configuration Keys for Plugins
+
+Each plugin object, whether defined inline or in a separate file, can include these properties.
+
+* `name` -- `string`
+
+  The name of the plugin. Will be used to namespace any configuration objects.
+
+* `rules` -- `Object`
+
+  Object that defines new rules.
+  Each key represents the name of the rule that is defined.
+  Each value should be a string that represents a relative file path to the rule definition. See [Rule APIs](#rule-apis) for more detail.
+
+* `configurations` -- `Object`
+
+  Object that defines new configurations that can be extended.
+  Each key represents the name of the configuration object.
+  Each value should be a configuration object, that can include the [same properties as the base config object](../README.md#configuration-keys) in any `.template-lintrc.js` -- i.e. `rules`, `extends`, `ignore`, etc.
+
+### Rule APIs
+
+Every rule defined by a plugin can use these public APIs defined by `ember-template-lint`.
+
+### Building a rule object
+
+Each file that defines a rule should export a function that accepts an `addonContext` object and returns a rule object.
+
+You can easily build a new rule object using `buildPlugin`, a helper function exported by [`ember-template-lint/lib/rules/base.js`](../lib/rules/base.js).
+
+Sample rule:
+
+```javascript
+'use strict';
+
+var buildPlugin = require('ember-template-lint/lib/rules/base');
+
+module.exports = function(addonContext) {
+  var NoEmptyComments = buildPlugin(addonContext, 'no-empty-comments');
+
+  NoEmptyComments.prototype.visitors = function() {
+    return {
+      CommentStatement: function(node) {
+        if (node.value.trim() === '') {
+          this.log({
+            message: 'comments cannot be empty',
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node)
+          });
+        }
+      }
+    };
+  };
+
+  return NoEmptyComments;
+};
+```
+
+`buildPlugin` takes two parameters:
+
+* `options` -- `Object`
+
+  Options for the linter. You can pass the `addonContext` object provided by your default function directly to `buildPlugin`.
+
+* `name` -- `string`
+
+  The name of your rule, to be displayed with any lint errors.
+
+`buildPlugin` returns a base rule object. You can override the following properties:
+
+* `function visitors(): visitorsObject`
+
+  The `visitors` function should return an object that maps Handlebars node types to functions. Whenever the Handlebars parser encounters a particular type of node, any visitor function that you define for that node will be called on it. You can reference the [Handlebars Compiler API](https://github.com/wycats/handlebars.js/blob/master/docs/compiler-api.md) for more detail on the types of nodes and their interfaces.
+
+The base rule object also has a few helper functions that can be useful in defining rule behavior:
+
+* `function log(options)`
+
+  Report a lint error. The `log` function accepts an Object as its only argument, which can contain the following parameters:
+    - `message` -- `string`
+      The error message to display.
+    - `line` -- `number`
+      The line number of the error in the source string.
+    - `column` -- `number`
+      The column number of the error in the source string.
+    - `source` -- `string`
+      The source string that caused the error.
+    - `fix` -- `string`
+      An optional string to display with the recommended fix.
+
+* `function sourceForNode(node): string`
+
+  Given a Handlebars AST node, return the string source of that node. Useful to generate `source` when logging errors with `log`.
+
+### AST Node Helpers
+
+There are a number of helper functions exported by [`ember-template-lint/lib/helpers/ast-node-info.js`](../lib/helpers/ast-node-info.js) that can be used with AST nodes in your rule's visitor functions.
+
+* `function isConfigurationHtmlComment(node): boolean`
+
+  Returns true if this node is an HTML comment that is meant to set linter configuration (i.e. `<!-- template-lint enabled=false -->`).
+
+* `function isNonConfigurationHtmlComment(node): boolean`
+
+  Returns true if this node is *not* an HTML comment that is meant to set linter configuration.
+
+* `function isTextNode(node): boolean`
+
+  Returns true if this node is a `TextNode` node.
+
+* `function isCommentStatement(node): boolean`
+
+  Returns true if this node is a `CommentStatement` node.
+
+* `function isMustacheCommentStatement(node): boolean`
+
+  Returns true if this node is a `MustacheCommentStatement` node.
+
+* `function isElementNode(node): boolean`
+
+  Returns true if this node is an `ElementNode` node.
+
+* `function isComponentNode(node): boolean`
+
+  Returns true if this node is a `ComponentNode` node.
+
+* `function isMustacheStatement(node): boolean`
+
+  Returns true if this node is a `MustacheStatement` node.
+
+* `function isBlockStatement(node): boolean`
+
+  Returns true if this node is a `BlockStatement` node.
+
+* `function hasAttribute(node, attributeName): boolean`
+
+  Returns true if this node has an attribute whose name matches `attributeName`.
+
+* `function findAttribute(node, attributeName): Object`
+
+  Returns any attributes on the node with a name that matches `attributeName`.
+
+* `function isImgElement(node): boolean`
+
+  Returns true if this node is an `img` element.
+
+* `function isLinkElement(node): boolean`
+
+  Returns true if this node is a link (`a`) element.
+
+* `function childrenFor(node): Object[]`
+
+  Returns any child nodes of this node.
+
+* `function hasChildren(node): boolean`
+
+  Returns true if this node has any child nodes.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -4,117 +4,11 @@ You can customize the linter with rules that are more specific to your use case 
 
 Plugins can define new rules and set up default configurations that can be extended.
 
-### Adding Plugins to Your Configuration
+### Defining plugin objects
 
-In order to enable a plugin, you must add it to the `plugins` key in your configuration file.
+Each plugin object can include these properties.
 
-`plugins` accepts an array of either plugin objects or strings to be passed to `require` which resolve to plugin objects.
-
-#### Define a plugin inline
-
-```javascript
-// .template-lintrc.js
-
-module.exports = {
-  plugins: [
-    {
-      // Name of plugin
-      name: 'some-inline-plugin',
-
-      // Define rules for this plugin. Each path should map to a plugin rule
-      rules: {
-        'disallow-inline-components': require('./lib/template-lint-rules/disallow-inline-components'),
-        'another-custom-rule': require('.lib/template-lint-rules/another-custom-rule')
-      },
-
-      // Define configurations for this plugin that can be extended by the base configuration
-      configurations: {
-        'no-inline': {
-            rules: {
-              'disallow-inline-components': true
-            }
-        }
-      }
-    },
-  ],
-
-  extends: [
-    // Extend configuration defined in the inline plugin
-    'no-inline'
-  ],
-
-  rules: {
-    'bare-strings': true,
-
-    // Use a rule defined in the inline plugin
-    'another-custom-rule': true
-  }
-}
-```
-
-#### Define a plugin based on a relative path
-```javascript
-// .template-lintrc.js
-
-module.exports = {
-  plugins: [
-    // Define a plugin that is exported elsewhere (i.e. a third-party plugin)
-    './plugins/some-local-plugin',
-    'some-npm-package/third-party-plugin',
-  ],
-
-  extends: [
-    'recommended',
-
-    // Extend configuration defined in plugins
-    'some-local-plugin:recommended',
-    'third-party-plugin:strict'
-  ],
-
-  rules: {
-    'bare-strings': true,
-
-    // Use a rule defined in a plugin
-    'rule-defined-in-some-local-plugin': true
-  }
-}
-
-```
-
-Each path included as part of `plugins` should resolve to a file that exports a plugin object.
-
-```javascript
-// plugins/some-local-plugin.js
-
-'use strict';
-
-module.exports = {
-
-  // Name of plugin
-  name: 'some-local-plugin',
-
-  // These rules will be added to the namespace of any config file that imports this plugin
-  rules: {
-    'inline-component': require('./rules/lint-inline-component')
-  },
-
-  // These configurations will be available to extend in any config file that imports this plugin, namespaced by the name of this plugin
-  configurations: {
-    recommended: {
-      rules: {
-        'inline-component': true,
-        'bare-strings': true
-      }
-    }
-  }
-};
-```
-
-### Configuration Keys for Plugins
-
-Each plugin object, whether defined inline or in a separate file, can include these properties.
-
-* `name` -- `string`
+* `name` -- `string` (required)
 
   The name of the plugin. Will be used to namespace any configuration objects.
 
@@ -129,6 +23,71 @@ Each plugin object, whether defined inline or in a separate file, can include th
   Object that defines new configurations that can be extended.
   Each key represents the name of the configuration object.
   Each value should be a configuration object, that can include the [same properties as the base config object](../README.md#configuration-keys) in any `.template-lintrc.js` -- i.e. `rules`, `extends`, `ignore`, etc.
+
+Sample plugin object:
+
+```javascript
+{
+  // Name of plugin
+  name: 'my-plugin',
+
+  // Define rules for this plugin. Each path should map to a plugin rule
+  rules: {
+    'disallow-inline-components': require('./lib/template-lint-rules/disallow-inline-components'),
+    'another-custom-rule': require('.lib/template-lint-rules/another-custom-rule')
+  },
+
+  // Define configurations for this plugin that can be extended by the base configuration
+  configurations: {
+    'no-inline': {
+      rules: {
+        'disallow-inline-components': true
+      }
+    }
+  }
+}
+```
+
+### Adding Plugins to Your Configuration
+
+In order to enable a plugin, you must add it to the `plugins` key in your configuration file.
+
+`plugins` accepts an array of either plugin objects or strings to be passed to `require` which resolve to plugin objects.
+
+```javascript
+// .template-lintrc.js
+
+module.exports = {
+  plugins: [
+
+    // Define a plugin inline
+    {
+      name: 'inline-plugin',
+
+      ...
+    },
+
+    // Define a plugin that is exported elsewhere (i.e. a third-party plugin)
+    './plugins/some-local-plugin',
+    'some-npm-package/third-party-plugin',
+  ],
+
+  extends: [
+    // Extend configuration defined in inline plugins
+    'configuration-defined-in-my-inline-plugin',
+
+    // Extend configuration defined in plugins in other files
+    'some-local-plugin:recommended',
+    'third-party-plugin:another-configuration'
+  ],
+
+  rules: {
+    // Use rules defined in plugins
+    'rule-defined-in-my-inline-plugin': true
+    'rule-defined-in-some-local-plugin': true
+  }
+}
+```
 
 ### Rule APIs
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -8,7 +8,7 @@ Plugins can define new rules and set up default configurations that can be exten
 
 In order to enable a plugin, you must add it to the `plugins` key in your configuration file.
 
-`plugins` accepts an array of either objects, or strings that resolve to files that export plugin objects.
+`plugins` accepts an array of either plugin objects or strings to be passed to `require` which resolve to plugin objects.
 
 #### Define a plugin inline
 
@@ -18,20 +18,23 @@ In order to enable a plugin, you must add it to the `plugins` key in your config
 module.exports = {
   plugins: [
     {
+      // Name of plugin
+      name: 'some-inline-plugin',
+
       // Define rules for this plugin. Each path should map to a plugin rule
-      rules: [
+      rules: {
         'disallow-inline-components': require('./lib/template-lint-rules/disallow-inline-components'),
         'another-custom-rule': require('.lib/template-lint-rules/another-custom-rule')
-      ],
+      },
 
       // Define configurations for this plugin that can be extended by the base configuration
-      configurations: [
+      configurations: {
         'no-inline': {
             rules: {
               'disallow-inline-components': true
             }
         }
-      ]
+      }
     },
   ],
 
@@ -131,7 +134,7 @@ Each plugin object, whether defined inline or in a separate file, can include th
 
 Every rule defined by a plugin can use these public APIs defined by `ember-template-lint`.
 
-### Building a rule object
+#### Building a rule object
 
 Each file that defines a rule should export a function that accepts an `addonContext` object and returns a rule object.
 
@@ -202,7 +205,7 @@ The base rule object also has a few helper functions that can be useful in defin
 
   Given a Handlebars AST node, return the string source of that node. Useful to generate `source` when logging errors with `log`.
 
-### AST Node Helpers
+#### AST Node Helpers
 
 There are a number of helper functions exported by [`ember-template-lint/lib/helpers/ast-node-info.js`](../lib/helpers/ast-node-info.js) that can be used with AST nodes in your rule's visitor functions.
 


### PR DESCRIPTION
For #167. First draft of documentation for the plugin support system. I'm still very new to this project, so would appreciate a careful review to ensure that I've correctly understood / communicated how the plugin system and rules APIs work.

- [x] how to set up a plugin in your config file (based on proposal in #136)
  - [x] inline plugins
  - [x] strings that resolve to plugin files
  - [x] options for plugins
    - [x] `name`
    - [x] `rules`
    - [x] `configurations`
  - [x] extending plugins
  - [x] using rules defined in plugins
- [x] public APIs that you can use in your plugin rules
  - [x] `buildPlugin` to set up base rule
  - [x] AST node helpers 

I also updated the usage documentation in the README — it looks like the API has changed for that method since the documentation was first written.

cc: @ppcano 

@rwjblue the documentation for plugins was a bit long, so I created a `docs` directory. Would you prefer to keep all documentation in the main README instead?