### PR TITLE
Recommended config: remove "deprecated-each-syntax" entry, obsolete for Ember 2.x.

### DIFF
--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -7,7 +7,6 @@ module.exports = {
     'nested-interactive': true,
     'self-closing-void-elements': true,
     'triple-curlies': true,
-    'deprecated-each-syntax': true,
     'link-rel-noopener': true,
     'invalid-interactive': true,
     'img-alt-attributes': true,


### PR DESCRIPTION
Recommended configuration: turn off `deprecated-each-syntax` rule, applicable only to Ember 1.x templates.

Related issue: #185 .