### PR TITLE
validate both noopener and noreferrer by extending the rule config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 ---
+before_install:
+    # if npm version is less than 3.0.0, upgrade to 3
+    - if [[ $(npm -v | cut -d '.' -f 1) -lt 3 ]]; then npm i -g npm@^3; fi
 language: node_js
 node_js:
   - "stable"

--- a/README.md
+++ b/README.md
@@ -345,8 +345,8 @@ to make the browser open this link in a new tab.
 However, this practice has performance problems (see [https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/](https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/))
 and also opens a door to some security attacks because the opened page can redirect the opener app
 to a malicious clone to perform phishing on your users.
-Adding `rel="noopener"` closes that door and avoids javascript in the opened tab to block the main
-thread in the opener. Also note that adding `rel="noreferrer"` will [acheive the same goal](https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer).
+Adding `rel="noopener noreferrer"` closes that door and avoids javascript in the opened tab to block the main
+thread in the opener. Also note that Firefox versions prior 52 do not implement `noopener` and `rel="noreferrer"` should be used instead [ see Firefox issue ](https://bugzilla.mozilla.org/show_bug.cgi?id=1222516) and https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer.
 
 This rule forbids the following:
 
@@ -357,12 +357,14 @@ This rule forbids the following:
 Instead, you should write the template as:
 
 ```hbs
-<a href="https://i.seem.secure.com" target="_blank" rel="noopener">I'm a bait</a>
+<a href="https://i.seem.secure.com" target="_blank" rel="noopener noreferrer">I'm a bait</a>
 ```
 
 The following values are valid configuration:
 
-  * boolean -- `true` for enabled / `false` for disabled
+  * string -- `strict` for enabled and validating both noopener `and` noreferrer
+  * boolean `true` to maintain backwards compatibility with previous versions of `ember-template-lint` that validate noopener `or` noreferrer
+  If you are supporting Firefox, you should use `strict`.
 
 #### invalid-interactive
 
@@ -417,7 +419,7 @@ The block form is a little longer but has advantages over the inline form:
 This rule is configured with one boolean value:
 
   * boolean -- `true` for enabled / `false` for disabled
-  
+
 #### inline-styles
 
 Inline styles are not the best practice because they are hard to maintain and usually make the overall size of the project bigger. This rule forbids the inline styles.

--- a/lib/rules/lint-link-rel-noopener.js
+++ b/lib/rules/lint-link-rel-noopener.js
@@ -37,7 +37,7 @@ module.exports = function(addonContext) {
 
     var errorMessage = 'The bare-strings rule accepts one of the following values.\n ' +
       '  * boolean - `true` to enable / `false` to disable\n' +
-      '  * array -- [`true`, `strict`] to enable validation for both noopener AND noreferrer\n' +
+      '  * string -- `strict` to enable validation for both noopener AND noreferrer\n' +
       '\nYou specified `' + JSON.stringify(config) + '`';
 
     switch (configType) {

--- a/lib/rules/lint-link-rel-noopener.js
+++ b/lib/rules/lint-link-rel-noopener.js
@@ -18,8 +18,44 @@ var buildPlugin = require('./base');
  <a href="/some/where" target="_blank"></a>
  ```
  */
+
+var DEFAULT_CONFIG = {
+  regexp: /no(opener|referrer)/,
+  message: 'links with target="_blank" must have rel="noopener"'
+};
+
+var STRICT_CONFIG = {
+  regexp: /no(opener.*referrer)/,
+  message: 'links with target="_blank" must have rel="noopener noreferrer"'
+};
+
 module.exports = function(addonContext) {
   var LinkRelNoopener = buildPlugin(addonContext, 'link-rel-noopener');
+
+  LinkRelNoopener.prototype.parseConfig = function(config) {
+    var configType = typeof config;
+
+    var errorMessage = 'The bare-strings rule accepts one of the following values.\n ' +
+      '  * boolean - `true` to enable / `false` to disable\n' +
+      '  * array -- [`true`, `strict`] to enable validation for both noopener AND noreferrer\n' +
+      '\nYou specified `' + JSON.stringify(config) + '`';
+
+    switch (configType) {
+    case 'boolean':
+      return config ? DEFAULT_CONFIG : false;
+    case 'string':
+      if (config === 'strict') {
+        return STRICT_CONFIG;
+      } else {
+        throw new Error(errorMessage);
+      }
+    case 'undefined':
+      return false;
+    default:
+      throw new Error(errorMessage);
+    }
+  };
+
 
   LinkRelNoopener.prototype.visitors = function() {
     return {
@@ -30,11 +66,11 @@ module.exports = function(addonContext) {
         var targetBlank = hasTargetBlank(node);
         if (!targetBlank) { return; }
 
-        var relNoopener = hasRelNoopener(node);
+        var relNoopener = hasRelNoopener(node, this.config.regexp);
         if (relNoopener) { return; }
 
         this.log({
-          message: 'links with target="_blank" must have rel="noopener"',
+          message: this.config.message,
           line: node.loc && node.loc.start.line,
           column: node.loc && node.loc.start.column,
           source: this.sourceForNode(node)
@@ -59,13 +95,13 @@ function hasTargetBlank(node) {
   }
 }
 
-function hasRelNoopener(node) {
+function hasRelNoopener(node, regexp) {
   var relAttribute = AstNodeInfo.findAttribute(node, 'rel');
   if (!relAttribute) { return false; }
 
   switch (relAttribute.value.type) {
   case 'TextNode':
-    return /no(opener|referrer)/.test(relAttribute.value.chars);
+    return regexp.test(relAttribute.value.chars);
   default:
     return false;
   }

--- a/test/unit/rules/lint-link-rel-noopener-test.js
+++ b/test/unit/rules/lint-link-rel-noopener-test.js
@@ -12,7 +12,11 @@ generateRuleTests({
     '<a href="/some/where" target="_self"></a>',
     '<a href="/some/where" target="_blank" rel="noopener"></a>',
     '<a href="/some/where" target="_blank" rel="noopener noreferrer"></a>',
-    '<a href="/some/where" target="_blank" rel="noreferrer"></a>'
+    '<a href="/some/where" target="_blank" rel="noreferrer"></a>',
+    {
+      config: 'strict',
+      template: '<a href="/some/where/ingrid" target="_blank" rel="noopener noreferrer"></a>,'
+    }
   ],
 
   bad: [
@@ -34,6 +38,45 @@ generateRuleTests({
       result: {
         rule: 'link-rel-noopener',
         message: 'links with target="_blank" must have rel="noopener"',
+        moduleId: 'layout.hbs',
+        source: '<a href="/some/where" target="_blank" rel="nofollow"></a>',
+        line: 1,
+        column: 0
+      }
+    },
+    {
+      config: 'strict',
+      template: '<a href="/some/where" target="_blank" rel="noopener"></a>',
+
+      result: {
+        rule: 'link-rel-noopener',
+        message: 'links with target="_blank" must have rel="noopener noreferrer"',
+        moduleId: 'layout.hbs',
+        source: '<a href="/some/where" target="_blank" rel="noopener"></a>',
+        line: 1,
+        column: 0
+      }
+    },
+    {
+      config: 'strict',
+      template: '<a href="/some/where" target="_blank" rel="noreferrer"></a>',
+
+      result: {
+        rule: 'link-rel-noopener',
+        message: 'links with target="_blank" must have rel="noopener noreferrer"',
+        moduleId: 'layout.hbs',
+        source: '<a href="/some/where" target="_blank" rel="noreferrer"></a>',
+        line: 1,
+        column: 0
+      }
+    },
+    {
+      config: 'strict',
+      template: '<a href="/some/where" target="_blank" rel="nofollow"></a>',
+
+      result: {
+        rule: 'link-rel-noopener',
+        message: 'links with target="_blank" must have rel="noopener noreferrer"',
         moduleId: 'layout.hbs',
         source: '<a href="/some/where" target="_blank" rel="nofollow"></a>',
         line: 1,


### PR DESCRIPTION
Fix for #187 .

This PR extends the configuration options for `link-rel-noopener` to allow enforcing validation for both `noopener` **and** `noreferrer` on  rule.

Backward compatibility is preserved by maintaining the boolean values `true` to enable and `false` to disable. 

To configure the new validation

``` javascript
module.exports = {
  rules: {
    'link-rel-noopener': [true, 'strict']
  }
}; 
```

cc @paddyobrien  and @GavinJoyce 