### PR TITLE
block rule missing error

### DIFF
--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -503,6 +503,23 @@ generateRuleTests({
     },
     {
       template: [
+        '{{#if media.isMobile}}',
+        '{{else}}',
+        '<span>',
+        '</span>',
+        '{{/if}}'
+      ].join('\n'),
+
+      result: {
+        message: 'Incorrect indentation for `<span>` beginning at L3:C0. Expected `<span>` to be at an indentation of 2 but was found at 0.',
+        moduleId: 'layout.hbs',
+        source: '{{#if media.isMobile}}\n{{else}}\n<span>\n</span>\n{{/if}}',
+        line: 3,
+        column: 0
+      }
+    },
+    {
+      template: [
         '\uFEFF {{#if foo}}',
         '{{/if}}'
       ].join('\n'),


### PR DESCRIPTION
test case

the error text right now is wrong because it is copy pasted, but it doesn't matter. This code is succeeding right now with no errors.