### PR TITLE
Adding deep link to rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ember-template-lint will lint your template and return error results. This is co
 used through ember-cli-template-lint which adds failing lint tests for consuming ember-cli
 applications.
 
-For example, given the rule `bare-strings` is enabled, this template would be
+For example, given the rule [`bare-strings`](https://github.com/rwjblue/ember-template-lint#bare-strings) is enabled, this template would be
 in violation:
 
 ```hbs


### PR DESCRIPTION
When I was reading the docs, I wanted to know where this rule was coming from. Adding the link helps clarify this is a rule part of the library.