### PR TITLE
invalid-interactive: allow form elements to have onsubmit attributes

### DIFF
--- a/lib/rules/lint-invalid-interactive.js
+++ b/lib/rules/lint-invalid-interactive.js
@@ -67,6 +67,11 @@ module.exports = function(addonContext) {
           let helperName = node.value.path.original;
 
           if (helperName === 'action') {
+            // Allow onsubmit={{action "foo"}} on form tags
+            if (this._element.tag === 'form' && node.name === 'onsubmit') {
+              return;
+            }
+
             this.log({
               message: 'Interaction added to non-interactive element',
               line: node.loc && node.loc.start.line,

--- a/test/unit/rules/lint-invalid-interactive-test.js
+++ b/test/unit/rules/lint-invalid-interactive-test.js
@@ -12,6 +12,7 @@ generateRuleTests({
     '<div role="button" {{action "foo"}}></div>',
     '<li><button {{action "foo"}}></button></li>',
     '<form {{action "foo" on="submit"}}></form>',
+    '<form onsubmit={{action "foo"}}></form>',
     {
       config: { additionalInteractiveTags: ['div'] },
       template: '<div {{action "foo"}}></div>'
@@ -42,6 +43,17 @@ generateRuleTests({
         line: 1,
         column: 5,
         source: '<div onclick={{action \"foo\"}}></div>'
+      }
+    },
+
+    {
+      template: '<div onsubmit={{action "foo"}}></div>',
+
+      result: {
+        message: 'Interaction added to non-interactive element',
+        line: 1,
+        column: 5,
+        source: '<div onsubmit={{action \"foo\"}}></div>'
       }
     },
 


### PR DESCRIPTION
The rule allows `<form {{action "foo" on="submit"}}>` but not `<form onsubmit={{action "foo"}}>`. Now it allows both.