### PR TITLE
Added 'disallow-log' rule

### DIFF
--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -3,6 +3,7 @@
 module.exports = {
   rules: {
     'block-indentation': 2,
+    'disallow-log': true,
     'html-comments': true,
     'nested-interactive': true,
     'self-closing-void-elements': true,

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -3,6 +3,7 @@
 module.exports = {
   'bare-strings': require('./lint-bare-strings'),
   'block-indentation': require('./lint-block-indentation'),
+  'disallow-log': require('./lint-disallow-log'),
   'html-comments': require('./lint-html-comments'),
   'img-alt-attributes': require('./lint-img-alt-attributes'),
   'inline-styles': require('./lint-inline-styles'),

--- a/lib/rules/lint-disallow-log.js
+++ b/lib/rules/lint-disallow-log.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const buildPlugin = require('./base');
+const message = 'Unexpected {{log}} usage.';
+
+module.exports = function(addonContext) {
+  return class DisallowLog extends buildPlugin(addonContext, 'disallow-log') {
+    _checkForLog(node) {
+      if (node.path.original === 'log') {
+        this.log({
+          message: message,
+          line: node.loc && node.loc.start.line,
+          column: node.loc && node.loc.start.column,
+          source: this.sourceForNode(node)
+        });
+      }
+    }
+
+    visitors() {
+      return {
+        MustacheStatement(node) {
+          this._checkForLog(node);
+        },
+
+        BlockStatement(node) {
+          this._checkForLog(node);
+        }
+      };
+    }
+  };
+};
+
+module.exports.message = message;

--- a/test/unit/rules/disallow-log-test.js
+++ b/test/unit/rules/disallow-log-test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+const message = require('../../../lib/rules/lint-disallow-log').message;
+
+generateRuleTests({
+  name: 'disallow-log',
+
+  config: true,
+
+  good: [
+    '{{foo}}',
+    '{{button}}'
+  ],
+
+  bad: [
+    {
+      template: '{{log}}',
+
+      result: {
+        rule: 'disallow-log',
+        message: message,
+        moduleId: 'layout.hbs',
+        source: '{{log}}',
+        line: 1,
+        column: 0
+      }
+    },
+    {
+      template: '{{log "Logs are best for debugging!"}}',
+
+      result: {
+        rule: 'disallow-log',
+        message: message,
+        moduleId: 'layout.hbs',
+        source: '{{log "Logs are best for debugging!"}}',
+        line: 1,
+        column: 0
+      }
+    },
+    {
+      template: '{{#log}}Arrgh!{{/log}}',
+
+      result: {
+        rule: 'disallow-log',
+        message: message,
+        moduleId: 'layout.hbs',
+        source: '{{#log}}Arrgh!{{/log}}',
+        line: 1,
+        column: 0
+      }
+    },
+    {
+      template: '{{#log "Foo"}}{{/log}}',
+
+      result: {
+        rule: 'disallow-log',
+        message: message,
+        moduleId: 'layout.hbs',
+        source: '{{#log "Foo"}}{{/log}}',
+        line: 1,
+        column: 0
+      }
+    }
+  ]
+});


### PR DESCRIPTION
A rule to prevent usage of `{{log}}` in templates has been added.
Fixes https://github.com/rwjblue/ember-template-lint/issues/194