### PR TITLE
Renamed disallow-log to no-log, added no-debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,15 @@ but allows the following:
 {{!-- comment goes here --}}
 ```
 
+#### no-debugger
+
+`{{debugger}}` will inject `debugger` statement into compiled template code and will pause its rendering if developer tools are open. That is undesirable in a production environment.
+
+This rule forbids usage of the following:
+
+```hbs
+{{debugger}}
+```
 
 
 #### no-log

--- a/README.md
+++ b/README.md
@@ -261,6 +261,19 @@ but allows the following:
 {{!-- comment goes here --}}
 ```
 
+
+
+#### no-log
+
+`{{log}}` will produce messages in the browser console. That is undesirable in a production environment.
+
+This rule forbids usage of the following:
+
+```hbs
+{{log}}
+{{log "foo" var}}
+```
+
 #### triple-curlies
 
 Usage of triple curly braces to allow raw HTML to be injected into the DOM is large vector for exploits of your application (especially when the raw HTML is user controllable ). Instead of using `{{{foo}}}`, you should use appropriate helpers or computed properties that return a `SafeString` (via `Ember.String.htmlSafe` generally) and ensure that user supplied data is properly escaped.

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -3,7 +3,7 @@
 module.exports = {
   rules: {
     'block-indentation': 2,
-    'disallow-log': true,
+    'no-log': true,
     'html-comments': true,
     'nested-interactive': true,
     'self-closing-void-elements': true,

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -3,6 +3,7 @@
 module.exports = {
   rules: {
     'block-indentation': 2,
+    'no-debugger': true,
     'no-log': true,
     'html-comments': true,
     'nested-interactive': true,

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -3,7 +3,7 @@
 module.exports = {
   'bare-strings': require('./lint-bare-strings'),
   'block-indentation': require('./lint-block-indentation'),
-  'disallow-log': require('./lint-disallow-log'),
+  'no-log': require('./lint-no-log'),
   'html-comments': require('./lint-html-comments'),
   'img-alt-attributes': require('./lint-img-alt-attributes'),
   'inline-styles': require('./lint-inline-styles'),

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -3,6 +3,7 @@
 module.exports = {
   'bare-strings': require('./lint-bare-strings'),
   'block-indentation': require('./lint-block-indentation'),
+  'no-debugger': require('./lint-no-debugger'),
   'no-log': require('./lint-no-log'),
   'html-comments': require('./lint-html-comments'),
   'img-alt-attributes': require('./lint-img-alt-attributes'),

--- a/lib/rules/lint-no-debugger.js
+++ b/lib/rules/lint-no-debugger.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const buildPlugin = require('./base');
+const message = 'Unexpected {{debugger}} usage.';
+
+module.exports = function(addonContext) {
+  return class NoDebugger extends buildPlugin(addonContext, 'no-debugger') {
+    _checkForDebugger(node) {
+      if (node.path.original === 'debugger') {
+        this.log({
+          message: message,
+          line: node.loc && node.loc.start.line,
+          column: node.loc && node.loc.start.column,
+          source: this.sourceForNode(node)
+        });
+      }
+    }
+
+    visitors() {
+      return {
+        MustacheStatement(node) {
+          this._checkForDebugger(node);
+        },
+
+        BlockStatement(node) {
+          this._checkForDebugger(node);
+        }
+      };
+    }
+  };
+};
+
+module.exports.message = message;

--- a/lib/rules/lint-no-log.js
+++ b/lib/rules/lint-no-log.js
@@ -4,7 +4,7 @@ const buildPlugin = require('./base');
 const message = 'Unexpected {{log}} usage.';
 
 module.exports = function(addonContext) {
-  return class DisallowLog extends buildPlugin(addonContext, 'disallow-log') {
+  return class NoLog extends buildPlugin(addonContext, 'no-log') {
     _checkForLog(node) {
       if (node.path.original === 'log') {
         this.log({

--- a/test/unit/rules/no-debugger-test.js
+++ b/test/unit/rules/no-debugger-test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+const message = require('../../../lib/rules/lint-no-debugger').message;
+
+generateRuleTests({
+  name: 'no-debugger',
+
+  config: true,
+
+  good: [
+    '{{foo}}',
+    '{{button}}'
+  ],
+
+  bad: [
+    {
+      template: '{{debugger}}',
+
+      result: {
+        rule: 'no-debugger',
+        message: message,
+        moduleId: 'layout.hbs',
+        source: '{{debugger}}',
+        line: 1,
+        column: 0
+      }
+    },
+    {
+      template: '{{debugger}}',
+
+      result: {
+        rule: 'no-debugger',
+        message: message,
+        moduleId: 'layout.hbs',
+        source: '{{debugger}}',
+        line: 1,
+        column: 0
+      }
+    },
+    {
+      template: '{{#debugger}}Invalid!{{/debugger}}',
+
+      result: {
+        rule: 'no-debugger',
+        message: message,
+        moduleId: 'layout.hbs',
+        source: '{{#debugger}}Invalid!{{/debugger}}',
+        line: 1,
+        column: 0
+      }
+    }
+  ]
+});

--- a/test/unit/rules/no-log-test.js
+++ b/test/unit/rules/no-log-test.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const message = require('../../../lib/rules/lint-disallow-log').message;
+const message = require('../../../lib/rules/lint-no-log').message;
 
 generateRuleTests({
-  name: 'disallow-log',
+  name: 'no-log',
 
   config: true,
 
@@ -18,7 +18,7 @@ generateRuleTests({
       template: '{{log}}',
 
       result: {
-        rule: 'disallow-log',
+        rule: 'no-log',
         message: message,
         moduleId: 'layout.hbs',
         source: '{{log}}',
@@ -30,7 +30,7 @@ generateRuleTests({
       template: '{{log "Logs are best for debugging!"}}',
 
       result: {
-        rule: 'disallow-log',
+        rule: 'no-log',
         message: message,
         moduleId: 'layout.hbs',
         source: '{{log "Logs are best for debugging!"}}',
@@ -42,7 +42,7 @@ generateRuleTests({
       template: '{{#log}}Arrgh!{{/log}}',
 
       result: {
-        rule: 'disallow-log',
+        rule: 'no-log',
         message: message,
         moduleId: 'layout.hbs',
         source: '{{#log}}Arrgh!{{/log}}',
@@ -54,7 +54,7 @@ generateRuleTests({
       template: '{{#log "Foo"}}{{/log}}',
 
       result: {
-        rule: 'disallow-log',
+        rule: 'no-log',
         message: message,
         moduleId: 'layout.hbs',
         source: '{{#log "Foo"}}{{/log}}',


### PR DESCRIPTION
- following [naming rules embraced by ESlint](http://eslint.org/docs/rules/), I have renamed `disallow-log` to `no-log`
- added documentation entry for `no-log`
- added `no-debugger` rule with documentation entry

