### PR TITLE
Added "byte order mark" test

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,7 +96,7 @@ class Linter {
     try {
       precompile(stripBom(options.source), {
         moduleName: options.moduleId,
-        rawSource: options.source,
+        rawSource: stripBom(options.source),
         plugins: {
           ast: this.buildASTPlugins(pluginConfig)
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 const precompile = require('glimmer-engine').precompile;
 const getConfig = require('./get-config');
+const stripBom = require('strip-bom');
 
 const WARNING_SEVERITY = 1;
 const ERROR_SEVERITY = 2;
@@ -93,7 +94,7 @@ class Linter {
     };
 
     try {
-      precompile(options.source, {
+      precompile(stripBom(options.source), {
         moduleName: options.moduleId,
         rawSource: options.source,
         plugins: {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "mocha-eslint": "^2.0.2",
     "mocha-only-detector": "^0.1.0",
     "rimraf": "^2.5.2",
+    "strip-bom": "^3.0.0",
     "testem": "^1.7.0"
   },
   "engines": {

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -509,6 +509,21 @@ generateRuleTests({
         line: 1,
         column: 6
       }
+    },
+    {
+      template: [
+        '\uFEFF {{#if foo}}',
+        '{{/if}}'
+      ].join('\n'),
+
+      result: {
+        rule: 'block-indentation',
+        message: 'Incorrect indentation for `if` beginning at L1:C1. Expected `{{/if}}` ending at L2:C7 to be at an indentation of 1 but was found at 0.',
+        moduleId: 'layout.hbs',
+        source: '{{#if foo}}\n{{/if}}',
+        line: 2,
+        column: 7
+      }
     }
   ]
 });

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -179,7 +179,12 @@ generateRuleTests({
         '  <!-- foo bar baz -->',
         '</div>'
       ].join('\n')
-    }
+    },
+    [
+      '\uFEFF{{#if foo}}',
+      '  <div></div>',
+      '{{/if}}'
+    ].join('\n')
   ],
 
   bad: [


### PR DESCRIPTION
Added failing test to unit test suite for block-indentation rule. The test input starts with a "byte order mark".

See issue #215