### PR TITLE
Ignore using minimatch expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The following properties are allowed in the root of the `.template-lintrc.js` co
   An array of module id's that are still pending. The goal of this array is to allow incorporating template linting
   into an existing project, without changing every single template file. You can add all existing templates to this `pending` listing
   and slowly work through them, while at the same time ensuring that new templates added to the project pass all defined rules.
-* `ignore` -- `string[]`
+* `ignore` -- `string[]|glob[]`
   An array of module id's that are to be completely ignored.
 * `plugins` -- `(string|Object)[]`
   An array of plugin objects, or strings that resolve to files that export plugin objects. See [plugin documentation](docs/plugins.md) for more details.

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -10,7 +10,6 @@ const defaultConfigurations = require('./config/index');
 
 const KNOWN_ROOT_PROPERTIES = ['extends', 'rules', 'pending', 'ignore', 'plugins'];
 
-
 function resolveConfigPath(configPath, pluginPath) {
 
   configPath = configPath || path.join(process.cwd(), '.template-lintrc');
@@ -200,7 +199,7 @@ function processExtends(config, options) {
 }
 
 function processIgnores(config) {
-  config.ignore = config.ignore.map((pattern) => Minimatch(pattern));
+  config.ignore = config.ignore.map((pattern) => new Minimatch(pattern));
 }
 
 function validateRules(config, options) {

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -4,6 +4,7 @@ const path = require('path');
 const resolve = require('resolve');
 const assign = require('lodash').assign;
 const chalk = require('chalk');
+const Minimatch = require('minimatch').Minimatch;
 const defaultRules = require('./rules');
 const defaultConfigurations = require('./config/index');
 
@@ -198,6 +199,10 @@ function processExtends(config, options) {
 
 }
 
+function processIgnores(config) {
+  config.ignore = config.ignore.map((pattern) => Minimatch(pattern));
+}
+
 function validateRules(config, options) {
   let logger = options.console || console;
   let invalidKeysFound = [];
@@ -224,6 +229,7 @@ module.exports = function(options) {
     processLoadedRules(config);
     processLoadedConfigurations(config);
     processExtends(config, options);
+    processIgnores(config);
 
     validateRules(config, options);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const precompile = require('@glimmer/compiler').precompile;
+const Minimatch = require('minimatch').Minimatch;
 const getConfig = require('./get-config');
 const stripBom = require('strip-bom');
 
@@ -79,7 +80,9 @@ class Linter {
     for (let i = 0; i < list.length; i++) {
       let item = list[i];
 
-      if (typeof item === 'string' && moduleId === item) {
+      if (item instanceof Minimatch && item.match(moduleId)) {
+        return true;
+      } else if (typeof item === 'string' && moduleId === item) {
         return true;
       } else if (item.moduleId === moduleId){
         return item;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@glimmer/syntax": "^0.25.1",
     "chalk": "^1.1.3",
     "lodash": "^4.11.1",
+    "minimatch": "^3.0.4",
     "node-glob": "^1.2.0",
     "resolve": "^1.1.3"
   },

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -301,6 +301,24 @@ describe('public api', function() {
       expect(result).to.deep.equal([]);
     });
 
+    it('does not include errors when marked as ignored using glob', function() {
+      linter = new Linter({
+        console: mockConsole,
+        config: {
+          rules: { 'bare-strings': true, 'block-indentation': true },
+          ignore: [ 'some/path/*' ]
+        }
+      });
+
+      let template = '<div>bare string</div>';
+      let result = linter.verify({
+        source: template,
+        moduleId: 'some/path/here'
+      });
+
+      expect(result).to.deep.equal([]);
+    });
+
   });
 
   describe('Linter using plugins', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -192,7 +192,7 @@ bluebird@^3.1.1, bluebird@^3.4.6:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
-brace-expansion@^1.0.0:
+brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
   dependencies:
@@ -383,7 +383,7 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
-debug@2.6.0:
+debug@2.6.0, debug@^2.1.1:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
   dependencies:
@@ -395,7 +395,7 @@ debug@2.6.1:
   dependencies:
     ms "0.7.2"
 
-debug@2.6.4, debug@^2.1.1:
+debug@2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.4.tgz#7586a9b3c39741c0282ae33445c4e8ac74734fe0"
   dependencies:
@@ -1223,6 +1223,12 @@ minimatch@^3.0.2:
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
     brace-expansion "^1.0.0"
+
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
 
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"


### PR DESCRIPTION
This pull-request adds the ability to use minimatch expressions to ignore files.
Example:

```javascript
// .template-lintrc
{
  ignore: ['some/path/**/*.hbs']
}
```

I think it solves the issue #214