### PR TITLE
Move strip-bom to dependencies (un-break atom plugin)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lodash": "^4.11.1",
     "minimatch": "^3.0.4",
     "node-glob": "^1.2.0",
-    "resolve": "^1.1.3"
+    "resolve": "^1.1.3",
+    "strip-bom": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^4.0.0",
@@ -36,7 +37,6 @@
     "mocha-eslint": "^3.0.1",
     "mocha-only-detector": "^0.1.0",
     "rimraf": "^2.5.2",
-    "strip-bom": "^3.0.0",
     "testem": "^1.7.0"
   },
   "engines": {


### PR DESCRIPTION
It's used from lib/index.js, so it needs to be a dependency, not a devDependency.

I suspect this hasn't come up before since `strip-bom` is a dependency of `ember-cli-htmlbars`, so Ember projects that do any template linting would already have `strip-bom` installed for other reasons. But I just tried updating the [linter-ember-template](https://github.com/binhums/linter-ember-template) plugin to the latest `ember-template-lint` and it breaks because of this missing dependency.