### PR TITLE
block-indentation: allow single-line blocks with inverses

### DIFF
--- a/lib/rules/lint-block-indentation.js
+++ b/lib/rules/lint-block-indentation.js
@@ -113,8 +113,14 @@ module.exports = class BlockIndentation extends Rule {
     };
   }
 
-  /*eslint no-unused-expressions: 0*/
   process(node) {
+    // Nodes that start and end on the same line cannot have any indentation
+    // issues (since the column of the start block was already checked in the
+    // parent's validateBlockChildren())
+    if (node.loc.start.line === node.loc.end.line) {
+      return;
+    }
+
     this.validateBlockElse(node);
     this.validateBlockEnd(node);
     this.validateBlockChildren(node);
@@ -316,11 +322,6 @@ module.exports = class BlockIndentation extends Rule {
 
   shouldValidateBlockEnd(node) {
     if (node._isElseIfBlock) {
-      return false;
-    }
-
-    // HTML elements that start and end on the same line are fine
-    if (node.loc.start.line === node.loc.end.line) {
       return false;
     }
 

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -65,6 +65,8 @@ generateRuleTests({
       '  <p>Hi!</p>\n' +
       '{{/if}}',
     '{{#if foo}}<p>Hi!</p>{{/if}}',
+    '{{#if foo}}<p>Hi!</p>{{else}}<p>Bye!</p>{{/if}}',
+    '{{#if foo}}<p>Hi!</p>{{else if bar}}<p>Hello!</p>{{else}}<p>Bye!</p>{{/if}}',
     '<div>\n' +
       '  <span>Foo</span>{{#some-thing}}<p>lorum ipsum</p>{{/some-thing}}\n' +
       '</div>',
@@ -524,6 +526,32 @@ generateRuleTests({
         line: 2,
         column: 7
       }
+    },
+    {
+      template: [
+        '{{#if foo}}foo{{else}}',
+        '  bar',
+        '{{/if}}'
+      ].join('\n'),
+
+      results: [
+        {
+          rule: 'block-indentation',
+          message: 'Incorrect indentation for inverse block of `{{#if}}` beginning at L1:C0. Expected `{{else}}` starting at L1:C14 to be at an indentation of 0 but was found at 14.',
+          moduleId: 'layout.hbs',
+          source: '{{#if foo}}foo{{else}}\n  bar\n{{/if}}',
+          line: 1,
+          column: 14
+        },
+        {
+          rule: 'block-indentation',
+          message: 'Incorrect indentation for `foo` beginning at L1:C11. Expected `foo` to be at an indentation of 2 but was found at 11.',
+          moduleId: 'layout.hbs',
+          source: '{{#if foo}}foo{{else}}\n  bar\n{{/if}}',
+          line: 1,
+          column: 11
+        }
+      ]
     }
   ]
 });


### PR DESCRIPTION
This rule previous allowed

```handlebars
{{#if foo}}foo{{/if}}
```

but not

```handlebars
{{#if foo}}foo{{else}}bar{{/if}}
```

Now it allows both (plus uglier forms with else ifs and whatnot).

Personally I'm not a big fan of a newly-allowed syntax that this enables:

```handlebars
{{#if man}}man{{else if this}}this{{else if is}}is{{else}}ugly{{/if}}
```

But I don't think that has any _indentation_ issues, so if we don't like that we should write another `no-super-fugly-if-blocks` rule.