### PR TITLE
Adding comment about using eslint-plugin-hbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,9 @@ Example usage:
 
 ### ESLint
 
-If you're using [ember-inline-component](https://github.com/knownasilya/ember-inline-component)
-for your templates, then your templates show up in your `.js.` files, and not
-in `.hbs` files. In this case, it's still possible to use `ember-template-lint`
-through an [eslint-plugin](https://github.com/psbanka/eslint-plugin-hbs).
+If you are using templates inlined into your JS files, you can leverage
+[eslint-plugin-hbs](https://github.com/psbanka/eslint-plugin-hbs) to integrate
+ember-template-lint into your normal eslint workflow.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Example usage:
 ./node_modules/.bin/ember-template-lint app/templates/application.hbs --json
 ```
 
+### ESLint
+
+If you're using [ember-inline-component](https://github.com/knownasilya/ember-inline-component)
+for your templates, then your templates show up in your `.js.` files, and not
+in `.hbs` files. In this case, it's still possible to use `ember-template-lint`
+through an [eslint-plugin](https://github.com/psbanka/eslint-plugin-hbs).
+
 ## Configuration
 
 ### Project Wide


### PR DESCRIPTION
Hello, we over at Fastly use your excellent tool for handlebars template linting, and we have started using [ember-inline-component](https://github.com/knownasilya/ember-inline-component) but were sad to see that we couldn't lint our templates any longer.

So we developed an [eslint plugin](https://github.com/psbanka/eslint-plugin-hbs) which uses `ember-template-lint` under the hood to check any template-literals that contain handlebars syntax. This just adds a note to your `README.md` file so people understand that this is an option.