### PR TITLE
Adding rule to check for template-length

### DIFF
--- a/docs/rule/template-length.md
+++ b/docs/rule/template-length.md
@@ -1,0 +1,24 @@
+#### template-length
+
+Some ember shops try to put some guard-rails on the length of templates for the following reasons:
+
+- Templates that are extremely long are often a sign that code should be
+  factored into several different components. Be aware that sometimes breaking
+  a template up just because it's long in order to satisfy linting-errors can
+  potentially make the code harder to reason about: splitting up a single
+  logical unit into multiple files simply because it is "long" roughly means that
+  to find where some HTML snippet is you have to solve a murder mystery. So while
+  this check is helpful to help with sanity-checking, `{{! template-disable template-length }}` 
+  might be the right answer if a long template does in fact represent a logical unit.
+
+- Templates that are extremely short might be better off inlined into the
+  component itself rather than existing as a separate `.hbs` file.
+
+This rule is configured with a boolean, or a string value:
+
+* boolean -- `true` for enabled (defaults of max: 200 / min: 5) / `false` for disabling this rule
+* object --
+  * max {number} - the longest a template should be without failing a test (assuming the
+    right thing to do would be to split the template up into pieces).
+  * min {number} - the shortest a template should be without failing a test (assuming the
+    right thing to do would be to inline the template.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -16,6 +16,7 @@
 * [self-closing-void-elements](rule/self-closing-void-elements.md)
 * [simple-unless](rule/simple-unless.md)
 * [style-concatenation](rule/style-concatenation.md)
+* [template-length](rule/template-length.md)
 * [triple-curlies](rule/triple-curlies.md)
 * [unused-block-params](rule/unused-block-params.md)
 

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -15,9 +15,6 @@ module.exports = {
     'style-concatenation': true,
     'deprecated-inline-view-helper': true,
     'simple-unless': true,
-    'unused-block-params': true,
-    'template-length': {
-      max: 200
-    },
+    'unused-block-params': true
   }
 };

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -15,6 +15,9 @@ module.exports = {
     'style-concatenation': true,
     'deprecated-inline-view-helper': true,
     'simple-unless': true,
-    'unused-block-params': true
+    'unused-block-params': true,
+    'template-length': {
+      max: 200
+    },
   }
 };

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -22,4 +22,5 @@ module.exports = {
   'no-duplicate-attributes': require('./lint-duplicate-attributes'),
   'linebreak-style': require('./lint-linebreak-style'),
   'attribute-indentation': require('./lint-attribute-indentation'),
+  'template-length': require('./lint-template-length')
 };

--- a/lib/rules/lint-template-length.js
+++ b/lib/rules/lint-template-length.js
@@ -5,12 +5,12 @@
 
  The following values are valid configuration:
 
-   * boolean -- `true` for enabled (same as `unix`) / `false` for disabled
+   * boolean -- `true` for enabled (defaults of max: 200 / min: 5) / `false` for disabling this rule
    * object --
      * max {number} - the longest a template should be without failing a test (assuming the
-       right thing to do would be to split the template up into pieces.
+       right thing to do would be to split the template up into pieces).
      * min {number} - the shortest a template should be without failing a test (assuming the
-       right thing to do would be to inline the template.
+       right thing to do would be to inline the template).
  */
 
 const Rule = require('./base');

--- a/lib/rules/lint-template-length.js
+++ b/lib/rules/lint-template-length.js
@@ -1,0 +1,93 @@
+'use strict';
+
+/*
+ Enforce template size constraints
+
+ The following values are valid configuration:
+
+   * boolean -- `true` for enabled (same as `unix`) / `false` for disabled
+   * object --
+     * max {number} - the longest a template should be without failing a test (assuming the
+       right thing to do would be to split the template up into pieces.
+     * min {number} - the shortest a template should be without failing a test (assuming the
+       right thing to do would be to inline the template.
+ */
+
+const Rule = require('./base');
+
+const MAX_LENGTH = 100;
+const MIN_LENGTH = 5;
+
+const DEFAULT_CONFIG = {
+  max: MAX_LENGTH,
+  min: MIN_LENGTH,
+};
+
+function isValidConfigObjectFormat(config) {
+  for (let key in config) {
+    let value = config[key];
+    let valueIsInteger = Number.isInteger(value);
+
+    if (key === 'min' && !valueIsInteger) {
+      return false;
+    } else if (key === 'max' && !valueIsInteger) {
+      return false;
+    }
+  }
+  return true;
+}
+
+module.exports = class LengthValidation extends Rule {
+  parseConfig(config) {
+    let configType = typeof config;
+
+    let errorMessage = 'The template-length rule accepts one of the following values.\n ' +
+      '  * boolean - `true` to enable / `false` to disable\n' +
+      '  * object -- An object with the following keys:' +
+      '    * `min` -- Minimum length of a template ' +
+      '    * `max` -- Maximum length of a template. ' +
+      '\nYou specified `' + JSON.stringify(config) + '`';
+
+    switch (configType) {
+    case 'boolean':
+      // if `true` use `DEFAULT_CONFIG`
+      return config ? DEFAULT_CONFIG : {};
+    case 'object':
+      if (isValidConfigObjectFormat(config)) {
+        return config;
+      } else {
+        throw new Error(errorMessage);
+      }
+    case 'undefined':
+      return {};
+    default:
+      throw new Error(errorMessage);
+    }
+  }
+
+  visitor() {
+    return {
+      Program(node) {
+        if (node.loc.start.line <= 1 && node.loc.start.column === 0 && node.loc.end.column === 0) {
+          const lines = node.body.map((chunk) => {
+            const source = this.sourceForNode(chunk);
+            return source.split('\n').length;
+          }).reduce((sum, value) => sum + value, 0);
+          if (this.config.max && lines > this.config.max) {
+            this.log({
+              message: `Template length of ${lines} exceeds ${this.config.max}`,
+              line: node.loc.start.line,
+              column: node.loc.start.column
+            });
+          } else if (this.config.min && lines < this.config.min) {
+            this.log({
+              message: `Template length of ${lines} is smaller than ${this.config.min}`,
+              line: node.loc.start.line,
+              column: node.loc.start.column
+            });
+          }
+        }
+      },
+    };
+  }
+};

--- a/lib/rules/lint-template-length.js
+++ b/lib/rules/lint-template-length.js
@@ -66,6 +66,7 @@ module.exports = class LengthValidation extends Rule {
   }
 
   visitor() {
+    let seenOuterProgram = false;
     return {
       Program: {
 
@@ -73,8 +74,7 @@ module.exports = class LengthValidation extends Rule {
         // be called if it has been disabled by any inline comments within the file.
 
         exit(node) {
-          if (node.loc.start.line > 1 || node.loc.start.column > 0) { return; }
-
+          if (seenOuterProgram === true) { return; }
           if (this.config.max && this.source.length > this.config.max) {
             this.log({
               message: `Template length of ${this.source.length} exceeds ${this.config.max}`,
@@ -88,6 +88,7 @@ module.exports = class LengthValidation extends Rule {
               column: node.loc.start.column
             });
           }
+          seenOuterProgram = true;
         }
       },
     };

--- a/lib/rules/lint-template-length.js
+++ b/lib/rules/lint-template-length.js
@@ -15,12 +15,12 @@
 
 const Rule = require('./base');
 
-const MAX_LENGTH = 100;
-const MIN_LENGTH = 5;
+const DEFAULT_MAX_LENGTH = 200;
+const DEFAULT_MIN_LENGTH = 5;
 
 const DEFAULT_CONFIG = {
-  max: MAX_LENGTH,
-  min: MIN_LENGTH,
+  max: DEFAULT_MAX_LENGTH,
+  min: DEFAULT_MIN_LENGTH
 };
 
 function isValidConfigObjectFormat(config) {
@@ -67,21 +67,23 @@ module.exports = class LengthValidation extends Rule {
 
   visitor() {
     return {
-      Program(node) {
-        if (node.loc.start.line <= 1 && node.loc.start.column === 0 && node.loc.end.column === 0) {
-          const lines = node.body.map((chunk) => {
-            const source = this.sourceForNode(chunk);
-            return source.split('\n').length;
-          }).reduce((sum, value) => sum + value, 0);
-          if (this.config.max && lines > this.config.max) {
+      Program: {
+
+        // implementation goes here in exit(): in the exit handler, the rule will not
+        // be called if it has been disabled by any inline comments within the file.
+
+        exit(node) {
+          if (node.loc.start.line > 1 || node.loc.start.column > 0) { return; }
+
+          if (this.config.max && this.source.length > this.config.max) {
             this.log({
-              message: `Template length of ${lines} exceeds ${this.config.max}`,
+              message: `Template length of ${this.source.length} exceeds ${this.config.max}`,
               line: node.loc.start.line,
               column: node.loc.start.column
             });
-          } else if (this.config.min && lines < this.config.min) {
+          } else if (this.config.min && this.source.length < this.config.min) {
             this.log({
-              message: `Template length of ${lines} is smaller than ${this.config.min}`,
+              message: `Template length of ${this.source.length} is smaller than ${this.config.min}`,
               line: node.loc.start.line,
               column: node.loc.start.column
             });

--- a/test/unit/rules/lint-template-length-test.js
+++ b/test/unit/rules/lint-template-length-test.js
@@ -8,8 +8,7 @@ generateRuleTests({
   config: true,
 
   good: [
-    'testing this',
-    'testing \n this',
+    'testing this\nand\nthis\nand\this',
     {
       config: {max: 10},
       template: 'testing\nthis\n'

--- a/test/unit/rules/lint-template-length-test.js
+++ b/test/unit/rules/lint-template-length-test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'template-length',
+
+  config: true,
+
+  good: [
+    'testing this',
+    'testing \n this',
+    {
+      config: {max: 10},
+      template: 'testing\nthis\n'
+    },
+    {
+      config: {min: 1},
+      template: 'testing\nthis\nand\this\n'
+    },
+    {
+      config: {min: 1, max: 5},
+      template: 'testing\nthis\nandthis\n'
+    },
+  ],
+
+  bad: [
+    {
+      config: {min: 10},
+      template: 'testing\ntoo-short template\n',
+
+      result: {
+        rule: 'template-length',
+        moduleId: 'layout.hbs',
+        message: 'Template length of 3 is smaller than 10',
+        line: 1,
+        column: 0,
+      }
+    },
+    {
+      config: {max: 3},
+      template: 'test\nthis\nand\nthis\n',
+
+      result: {
+        rule: 'template-length',
+        moduleId: 'layout.hbs',
+        message: 'Template length of 5 exceeds 3',
+        line: 1,
+        column: 0,
+      }
+    /*
+    },
+    {
+      config: true,
+      template: Array(200).fill().map('test this\n').join(),
+
+      result: {
+        rule: 'template-length',
+        moduleId: 'layout.hbs',
+        message: 'Wrong linebreak used. Expected LF but found CRLF',
+        line: 1,
+        column: 8,
+        source: '\r\n'
+      }
+      */
+    }
+  ]
+});

--- a/test/unit/rules/lint-template-length-test.js
+++ b/test/unit/rules/lint-template-length-test.js
@@ -47,21 +47,6 @@ generateRuleTests({
         line: 1,
         column: 0,
       }
-    /*
-    },
-    {
-      config: true,
-      template: Array(200).fill().map('test this\n').join(),
-
-      result: {
-        rule: 'template-length',
-        moduleId: 'layout.hbs',
-        message: 'Wrong linebreak used. Expected LF but found CRLF',
-        line: 1,
-        column: 8,
-        source: '\r\n'
-      }
-      */
     }
   ]
 });


### PR DESCRIPTION
Hi there, I'd love to be able to add a linting rule (ideally as a plugin) to have the linter fail when a template is over a certain size (assuming it should be broken up into pieces) or BELOW a certain size (assuming it should be inlined into a component).

~For some reason, disabling tests through instruction comments does
not seem to work and unit tests failing. If anyone has any idea what might be wrong here, I'd certainly appreciate the assistance. I wonder if we are not getting the configuration change because I'm using the `Program` hook to look for template-length?~