### PR TITLE
rule lint-simple-unless throws an error when template contains an emp…

### DIFF
--- a/lib/rules/lint-simple-unless.js
+++ b/lib/rules/lint-simple-unless.js
@@ -28,7 +28,7 @@ module.exports = class LintSimpleUnless extends Rule {
             } else {
               this._followingElseBlock(node);
             }
-          } else if (nodePathOriginal === 'if') {
+          } else if (nodePathOriginal === 'if' && nodeInverse.body[0]) {
             if (nodeInverse.body[0].path && nodeInverse.body[0].path.original  === 'unless') {
               this._asElseUnlessBlock(node);
             }

--- a/test/unit/rules/lint-simple-unless-test.js
+++ b/test/unit/rules/lint-simple-unless-test.js
@@ -12,6 +12,7 @@ generateRuleTests({
     '<div class="{{unless foo \'no-foo\'}}"></div>',
     '<div class="{{if foo \'foo\'}}"></div>',
     '{{unrelated-mustache-without-params}}',
+    '{{#if foo}}{{else}}{{/if}}',
     [
       '{{#unless hamburger}}',
       '  HOT DOG!',


### PR DESCRIPTION
…ty inverse block

/template.hbs
  -:-  error  Cannot read property 'path' of undefined  undefined