### PR TITLE
Make unit ember-template-lint-tes run on windows

### DIFF
--- a/test/unit/bin/ember-template-lint-test.js
+++ b/test/unit/bin/ember-template-lint-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const exec = require('child_process').exec;
+const execFile = require('child_process').execFile;
 const expect = require('chai').expect;
 const path = require('path');
 
@@ -8,7 +8,7 @@ describe('ember-template-lint executable', function() {
   describe('basic usage', function() {
     describe('without any parameters', function() {
       it('should exit without error and any console output', function(done) {
-        exec('./bin/ember-template-lint.js', function(err, stdout, stderr) {
+        execFile('node', ['./bin/ember-template-lint.js'], function(err, stdout, stderr) {
           expect(err).to.be.null;
           expect(stdout).to.be.empty;
           expect(stderr).to.be.empty;
@@ -19,7 +19,7 @@ describe('ember-template-lint executable', function() {
 
     describe('given path to non-existing file', function() {
       it('should exit without error and any console output', function(done) {
-        exec('../../../bin/ember-template-lint.js app/templates/application-1.hbs', {
+        execFile('node', ['../../../bin/ember-template-lint.js', 'app/templates/application-1.hbs'], {
           cwd: './test/fixtures/with-errors'
         }, function(err, stdout, stderr) {
           expect(err).to.equal(null, 'exits without error');
@@ -32,7 +32,7 @@ describe('ember-template-lint executable', function() {
 
     describe('given path to single file with errors', function() {
       it('should print errors', function(done) {
-        exec('../../../bin/ember-template-lint.js app/templates/application.hbs', {
+        execFile('node', ['../../../bin/ember-template-lint.js', 'app/templates/application.hbs'], {
           cwd: './test/fixtures/with-errors'
         }, function(err, stdout, stderr) {
           expect(err).to.be.ok;
@@ -45,7 +45,7 @@ describe('ember-template-lint executable', function() {
 
     describe('given wildcard path resolving to single file', function() {
       it('should print errors', function(done) {
-        exec('../../../bin/ember-template-lint.js app/templates/*', {
+        execFile('node', ['../../../bin/ember-template-lint.js', 'app/templates/*'], {
           cwd: './test/fixtures/with-errors'
         }, function(err, stdout, stderr) {
           expect(err).to.be.ok;
@@ -58,7 +58,7 @@ describe('ember-template-lint executable', function() {
 
     describe('given directory path', function() {
       it('should print errors', function(done) {
-        exec('../../../bin/ember-template-lint.js app', {
+        execFile('node', ['../../../bin/ember-template-lint.js', 'app'], {
           cwd: './test/fixtures/with-errors'
         }, function(err, stdout, stderr) {
           expect(err).to.be.ok;
@@ -71,7 +71,7 @@ describe('ember-template-lint executable', function() {
 
     describe('given path to single file without errors', function() {
       it('should exit without error and any console output', function(done) {
-        exec('../../../bin/ember-template-lint.js app/templates/application.hbs', {
+        execFile('node', ['../../../bin/ember-template-lint.js', 'app/templates/application.hbs'], {
           cwd: './test/fixtures/without-errors'
         }, function(err, stdout, stderr) {
           expect(err).to.be.null;
@@ -86,7 +86,7 @@ describe('ember-template-lint executable', function() {
   describe('errors formatting', function() {
     describe('without --json param', function() {
       it('should print properly formatted verbose error messages', function(done) {
-        exec('../../../bin/ember-template-lint.js .', {
+        execFile('node', ['../../../bin/ember-template-lint.js', '.'], {
           cwd: './test/fixtures/with-errors'
         }, function(err, stdout, stderr) {
           expect(err).to.be.ok;
@@ -106,7 +106,7 @@ describe('ember-template-lint executable', function() {
 
     describe('with --json param', function() {
       it('should print valid JSON string with errors', function(done) {
-        exec('../../../bin/ember-template-lint.js . --json', {
+        execFile('node', ['../../../bin/ember-template-lint.js', '.', '--json'], {
           cwd: './test/fixtures/with-errors'
         }, function(err, stdout, stderr) {
           let fullTemplateFilePath = path.resolve('./test/fixtures/with-errors/app/templates/application.hbs');


### PR DESCRIPTION
Previously the unit tests that ran ember-template-lint using node failed on windows, due to using forward slashes instead of backslashes as path seperator. But also it is not possible to just execute a .js file in windows. You have to provide a "real" executable to run, in this case node.

So I changed the uses of exec to use execFile with node as the first argument. This was not strictly needed, but execFile has better support for passing arguments and is a bit more efficient, so I saw it as an opportunity to change that as well.

This requires node to be in the PATH, so that it can be executed without an absolute path. Not sure if that is an issue for running it on OSX and Linux.