### PR TITLE
Allow colgroup and caption in tables

### DIFF
--- a/lib/rules/lint-table-groups.js
+++ b/lib/rules/lint-table-groups.js
@@ -3,22 +3,14 @@
 const Rule = require('./base');
 const message = 'Tables must have a table group (thead, tbody or tfoot).';
 
-const TABLE_GROUPS = ['thead', 'tbody', 'tfoot'];
+const ALLOWED_TABLE_CHILDREN = ['thead', 'tbody', 'tfoot', 'caption', 'colgroup'];
 
-function hasTableGroup(tableNode) {
+function hasDisallowedChildren(tableNode) {
   const tableGroup = tableNode.children.find((child) => {
-    return child.type === 'ElementNode' && TABLE_GROUPS.indexOf(child.tag) > -1;
+    return !(child.type === 'ElementNode' && ALLOWED_TABLE_CHILDREN.indexOf(child.tag) > -1);
   });
 
   return !!tableGroup;
-}
-
-function hasTableRows(tableNode) {
-  const tableRow = tableNode.children.find((child) => {
-    return child.type === 'ElementNode' && child.tag === 'tr';
-  });
-
-  return !!tableRow;
 }
 
 function hasChildTags(tableNode) {
@@ -38,7 +30,7 @@ module.exports = class TableGroups extends Rule {
             return;
           }
 
-          if (!hasTableGroup(node) || hasTableRows(node)) {
+          if (hasDisallowedChildren(node)) {
             this.log({
               message: message,
               line: node.loc && node.loc.start.line,

--- a/test/unit/rules/lint-table-groups-test.js
+++ b/test/unit/rules/lint-table-groups-test.js
@@ -10,6 +10,8 @@ generateRuleTests({
 
   good: [
     '<table> </table>',
+    '<table><caption>Foo</caption></table>',
+    '<table><colgroup><col style="background-color: red"></colgroup></table>',
     '<table><thead><tr><td>Header</td></tr></thead></table>',
     '<table><tbody><tr><td>Body</td></tr></tbody></table>',
     '<table><tfoot><tr><td>Footer</td></tr></tfoot></table>',


### PR DESCRIPTION
Fixes #285 

Basically only `thead`, `tbody`, `tfoot`, `caption` and `colgroup` are allowed children for tables.