### PR TITLE
Colorize error severity + typo

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -165,10 +165,6 @@ class Linter {
 
   static _formatError(error, options) {
     let message = '';
-    let severities = {
-      1: 'warrning',
-      2: 'error'
-    };
 
     if (error.line && error.column) {
       message += chalk.dim(`  ${error.line}:${error.column}`);
@@ -176,7 +172,12 @@ class Linter {
       message += chalk.dim('  -:-');
     }
 
-    message += `  ${chalk.red(severities[error.severity] || 'error')}`;
+    if (error.severity === WARNING_SEVERITY) {
+      message += `  ${chalk.yellow('warning')}`;
+    } else {
+      message += `  ${chalk.red('error')}`;
+    }
+
     message += `  ${error.message}  ${chalk.dim(error.rule)}`;
 
     if (options.verbose) {


### PR DESCRIPTION
- Render warnings messages in yellow.
- Fixed typo, from `warrning` (double `r`) to `warning`.

![warning](https://cdn.pbrd.co/images/GOgo1RT.png)