### PR TITLE
add more it.only support

### DIFF
--- a/test/helpers/rule-test-harness.js
+++ b/test/helpers/rule-test-harness.js
@@ -47,7 +47,7 @@ module.exports = function(options) {
         return assign({}, defaults, result);
       }
 
-      it(`logs a message in the console when given \`${template}\``, function() {
+      testMethod(`logs a message in the console when given \`${template}\``, function() {
         let expectedResults = badItem.results || [badItem.result];
 
         expectedResults = expectedResults.map(parseResult);
@@ -61,7 +61,7 @@ module.exports = function(options) {
         expect(actual).to.deep.equal(expectedResults);
       });
 
-      it(`passes with \`${template}\` when rule is disabled`, function() {
+      testMethod(`passes with \`${template}\` when rule is disabled`, function() {
         config = false;
         let actual = verify(template);
 
@@ -74,7 +74,7 @@ module.exports = function(options) {
         expect(actual).to.deep.equal([]);
       });
 
-      it(`passes with \`${template}\` when disabled via inline comment - all rules`, function() {
+      testMethod(`passes with \`${template}\` when disabled via inline comment - all rules`, function() {
         let actual = verify(DISABLE_ALL + '\n' + template);
 
         expect(actual).to.deep.equal([]);


### PR DESCRIPTION
It seems like all of these would want to be run when `focus`ing on a bad item.