### PR TITLE
Enable `eslint-plugin-node` recommended config.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,8 @@ module.exports = {
   "env": {
     "node": true
   },
-  "extends": "eslint:recommended",
+  "plugins": ["node"],
+  "extends": ["eslint:recommended", "plugin:node/recommended"],
   "rules": {
     "indent": [
       2,

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,7 @@
 /bower_components
 /config/ember-try.js
 /dist
-/tests
+/test
 /tmp
 **/.gitkeep
 .bowerrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: node_js
 node_js:
   - "stable"
+  - "8"
   - "6"
   - "4"
 

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -74,6 +74,7 @@ function run() {
   }, {});
 
   if (Object.keys(errors).length) printErrors(errors);
+  // eslint-disable-next-line no-process-exit
   if (exitCode) return process.exit(exitCode);
 }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "chai": "^4.0.0",
-    "eslint-plugin-node": "^5.1.0",
+    "eslint-plugin-node": "^5.2.1",
     "glob": "^7.0.0",
     "mocha": "^4.0.0",
     "mocha-eslint": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@glimmer/compiler": "^0.29.0",
     "@glimmer/syntax": "^0.29.0",
     "chalk": "^2.0.0",
+    "glob": "^7.0.0",
     "lodash": "^4.11.1",
     "minimatch": "^3.0.4",
     "resolve": "^1.1.3",
@@ -30,7 +31,6 @@
   "devDependencies": {
     "chai": "^4.0.0",
     "eslint-plugin-node": "^5.2.1",
-    "glob": "^7.0.0",
     "mocha": "^4.0.0",
     "mocha-eslint": "^4.1.0",
     "mocha-only-detector": "^0.1.0",

--- a/test/eslint-test.js
+++ b/test/eslint-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const lint = require('mocha-eslint');
 
 const paths = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,6 +550,15 @@ eslint-plugin-node@^5.1.0:
     resolve "^1.3.3"
     semver "5.3.0"
 
+eslint-plugin-node@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz#80df3253c4d7901045ec87fa660a284e32bdca29"
+  dependencies:
+    ignore "^3.3.6"
+    minimatch "^3.0.4"
+    resolve "^1.3.3"
+    semver "5.3.0"
+
 eslint-scope@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
@@ -923,6 +932,10 @@ iconv-lite@^0.4.17:
 ignore@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
+
+ignore@^3.3.6:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
 imurmurhash@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
This ensures that:

* we only use features compatible with our `package.json`'s engine config.
* we do not require a package that is not a dependency
* we do not require a file that is excluded from npm publishing

Fix issues identified by `plugin:node/recommended`:

* Add `'use strict'` where required
* Move `glob` to a dep

Fixes #309