### PR TITLE
remove usused plugin object fallback

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -37,10 +37,7 @@ function ensureRootProperties(config, source, options) {
   config.rules = assign({}, source.rules || {});
   config.pending = (source.pending || []).slice();
   config.ignore = (source.ignore || []).slice();
-
-  let plugins = source.plugins || [];
-  config.plugins = Array.isArray(plugins) ? plugins.slice() : assign({}, plugins);
-
+  config.plugins = (source.plugins || []).slice();
 
   let extendedList = [];
   if (source.extends) {


### PR DESCRIPTION
If `plugins` was an object, it would fail on this line https://github.com/rwjblue/ember-template-lint/blob/f568dca61c3a87a6dcf364cdb0cd5b0347fa198a/lib/get-config.js#L89, so I think it is safe to remove this code.