### PR TITLE
Add failing test case

### DIFF
--- a/lib/rules/lint-eol-last.js
+++ b/lib/rules/lint-eol-last.js
@@ -58,6 +58,14 @@ module.exports = class EolLast extends Rule {
             return;
           }
 
+          let bodyLength = node.body.length;
+          // if there is a block component invocation without a body
+          // it will make it here too
+          // check for that case
+          if (bodyLength === 0) {
+            return;
+          }
+
           let source = this.sourceForNode(node);
 
           let lastChar = source[source.length - 1];

--- a/test/unit/rules/lint-eol-last-test.js
+++ b/test/unit/rules/lint-eol-last-test.js
@@ -20,6 +20,10 @@ generateRuleTests({
       template: '{{#my-component}}\n' +
       '  test\n' +
       '{{/my-component}}'
+    },
+    {
+      config: 'always',
+      template: '{{#my-component}}{{/my-component}}\n'
     }
   ],
 


### PR DESCRIPTION
I believe I found a bug. Whenever there is a component in a block form, but it has no content inside, template lint will believe it violates the `eol-last` rule.

Fix I provided solves the issue.

Please let me know if I understand what's going on here correctly, and if there is anything I can do more to help fix this issue.