### PR TITLE
Failing test case for attribute-indentation

### DIFF
--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -52,6 +52,10 @@ generateRuleTests({
     ' {{contact.fullName}}' + '\n' +
     '{{/contact-details}}',
 
+    '{{yield (hash' +
+    '  header=(component "x-very-long-name-header")' +
+    '  body=(component "x-very-long-name-body"))' +
+    '}}',
     //Block form with open-invocation more than 80 characters
     {
       config: {


### PR DESCRIPTION
I'm providing failing test case for attribute-indentation rule, as discussed in https://github.com/rwjblue/ember-template-lint/issues/331

I have no clue what the expected format is in this case, I don't think it's handled. If handling this case isn't supposed to be handled by this rule, maybe it can ignore this case?

Please let me know if there is anything more I can do to help nailing this down.