### PR TITLE
Allow form elements to have reset actions

### DIFF
--- a/lib/rules/lint-invalid-interactive.js
+++ b/lib/rules/lint-invalid-interactive.js
@@ -47,6 +47,11 @@ module.exports = class InvalidInteractive extends Rule {
             return;
           }
 
+          // Allow {{action "foo" on="reset"}} on form tags
+          if (this._element.tag === 'form' && isResetAction(node)) {
+            return;
+          }
+
           this.log({
             message: 'Interaction added to non-interactive element',
             line: node.loc && node.loc.start.line,
@@ -71,6 +76,11 @@ module.exports = class InvalidInteractive extends Rule {
             return;
           }
 
+          // Allow onreset={{action "foo"}} on form tags
+          if (this._element.tag === 'form' && node.name === 'onreset') {
+            return;
+          }
+
           this.log({
             message: 'Interaction added to non-interactive element',
             line: node.loc && node.loc.start.line,
@@ -86,7 +96,7 @@ module.exports = class InvalidInteractive extends Rule {
   }
 };
 
-function isSubmitAction(node) {
+function isActionName(node, name) {
   let hashPairs = node.hash.pairs || [];
   let i;
   let l = hashPairs.length;
@@ -94,10 +104,18 @@ function isSubmitAction(node) {
 
   for (i = 0; i < l; i++) {
     hashItem = hashPairs[i];
-    if (hashItem.key === 'on' && hashItem.value.value === 'submit') {
+    if (hashItem.key === 'on' && hashItem.value.value === name) {
       return true;
     }
   }
 
   return false;
+}
+
+function isSubmitAction(node) {
+  return isActionName(node, 'submit');
+}
+
+function isResetAction(node) {
+  return isActionName(node, 'reset');
 }

--- a/test/unit/rules/lint-invalid-interactive-test.js
+++ b/test/unit/rules/lint-invalid-interactive-test.js
@@ -13,6 +13,8 @@ generateRuleTests({
     '<li><button {{action "foo"}}></button></li>',
     '<form {{action "foo" on="submit"}}></form>',
     '<form onsubmit={{action "foo"}}></form>',
+    '<form {{action "foo" on="reset"}}></form>',
+    '<form onreset={{action "foo"}}></form>',
     {
       config: { additionalInteractiveTags: ['div'] },
       template: '<div {{action "foo"}}></div>'


### PR DESCRIPTION
An exception to the invalid-interactive rule already exists for allowing `onsubmit` attributes and `{{action "foo" on="submit"}}` on form elements. This makes that same exception for `reset` events. 

- allow `onreset={{action "foo"}}` on form tags
- allow `{{action "foo" on="reset"}}` on form tags