### PR TITLE
feat(lint-simple-unless): add whitelist

### DIFF
--- a/docs/rule/simple-unless.md
+++ b/docs/rule/simple-unless.md
@@ -35,8 +35,6 @@ logic within the template.
 The following values are valid configuration:
 
   * boolean -- `true` for enabled / `false` for disabled
-  * array -- `whitelist` ```['or']``` for specific helpers / ```[]``` for wildcard, `maxHelpers` defaults to 1
-  * number -- `maxHelpers`, `whitelist` will be wildcard
   * object --
-    * `whitelist` -- array
+    * `whitelist` -- array - `['or']` for specific helpers / `[]` for wildcard
     * `maxHelpers` -- number

--- a/docs/rule/simple-unless.md
+++ b/docs/rule/simple-unless.md
@@ -35,3 +35,8 @@ logic within the template.
 The following values are valid configuration:
 
   * boolean -- `true` for enabled / `false` for disabled
+  * array -- `whitelist` ```['or']``` for specific helpers / ```[]``` for wildcard, `maxHelpers` defaults to 1
+  * number -- `maxHelpers`, `whitelist` will be wildcard
+  * object --
+    * `whitelist` -- array
+    * `maxHelpers` -- number

--- a/lib/rules/lint-simple-unless.js
+++ b/lib/rules/lint-simple-unless.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Rule = require('./base');
+const createErrorMessage = require('../helpers/create-error-message');
 
 const messages = {
   followingElseBlock: 'Using an {{else}} block with {{unless}} should be avoided.',
@@ -8,7 +9,56 @@ const messages = {
   withHelper: 'Using {{unless}} in combination with other helpers should be avoided.'
 };
 
+const DEFAULT_CONFIG = {
+  whitelist: [],
+};
+
+function isValidConfigObjectFormat(config) {
+  for (let key in config) {
+    let value = config[key];
+    let valueIsArray = Array.isArray(value);
+
+    if (key === 'whitelist' && !valueIsArray) {
+      return false;
+    } else if (DEFAULT_CONFIG[key] === undefined){
+      return false;
+    }
+  }
+
+  return true;
+}
+
 module.exports = class LintSimpleUnless extends Rule {
+  parseConfig(config) {
+    let configType = typeof config;
+
+    switch (configType) {
+    case 'boolean':
+      // if `true` use `DEFAULT_CONFIG`
+      return config ? DEFAULT_CONFIG : false;
+    case 'object':
+      if (Array.isArray(config)) {
+        return {
+          whitelist: config
+        };
+      } else if (isValidConfigObjectFormat(config)) {
+        // default any missing keys to empty values
+        return {
+          whitelist: config.whitelist || []
+        };
+      }
+      break;
+    case 'undefined':
+      return false;
+    }
+
+    let errorMessage = createErrorMessage(this.ruleName, [
+      '  * array -- an array of helpers to whitelist'
+    ], config);
+
+    throw new Error(errorMessage);
+  }
+
   visitor() {
     return {
       MustacheStatement(node) {
@@ -65,18 +115,48 @@ module.exports = class LintSimpleUnless extends Rule {
   }
 
   _withHelper(node) {
-    let loc = node.params[0].loc.start;
-    let actual = `{{unless (${node.params[0].path.original} ...`;
+    let whitelist = this.config.whitelist;
 
-    this._logMessage(messages.withHelper, loc.line, loc.column, actual);
+    if (typeof whitelist !== 'undefined' && whitelist.length > 0) {
+      let params;
+      let nextParams = node.params;
+      let containsSubexpression = false;
+
+      do {
+        params = nextParams;
+        nextParams = [];
+
+        params.forEach(param => {
+          if (param.type === 'SubExpression') {
+            param.params.forEach(param => nextParams.push(param));
+
+            if (!whitelist.includes(param.path.original)) {
+              let loc = param.loc.start;
+              let actual = `{{unless (${param.path.original} ...`;
+              let message = `${messages.withHelper} Allowed helper${whitelist.length > 1 ? 's' : ''}: ${whitelist.toString()}`;
+              //TODO make const
+
+              this._logMessage(message, loc.line, loc.column, actual);
+            }
+          }
+        });
+        containsSubexpression = nextParams.some(param => param.type  === 'SubExpression');
+      } while (containsSubexpression);
+
+    } else {
+      let loc = node.params[0].loc.start;
+      let actual = `{{unless (${node.params[0].path.original} ...`;
+
+      this._logMessage(messages.withHelper, loc.line, loc.column, actual);
+    }
   }
 
-  _logMessage(message, line, column, actual) {
+  _logMessage(message, line, column, source) {
     return this.log({
       message,
-      line: line,
-      column: column,
-      source: actual
+      line,
+      column,
+      source
     });
   }
 };

--- a/lib/rules/lint-simple-unless.js
+++ b/lib/rules/lint-simple-unless.js
@@ -11,6 +11,7 @@ const messages = {
 
 const DEFAULT_CONFIG = {
   whitelist: [],
+  maxHelpers: 0
 };
 
 function isValidConfigObjectFormat(config) {
@@ -36,15 +37,21 @@ module.exports = class LintSimpleUnless extends Rule {
     case 'boolean':
       // if `true` use `DEFAULT_CONFIG`
       return config ? DEFAULT_CONFIG : false;
+    case 'number':
+      return {
+        maxHelpers: config
+      };
     case 'object':
       if (Array.isArray(config)) {
         return {
-          whitelist: config
+          whitelist: config,
+          maxHelpers: 1
         };
       } else if (isValidConfigObjectFormat(config)) {
         // default any missing keys to empty values
         return {
-          whitelist: config.whitelist || []
+          whitelist: config.whitelist || [],
+          maxHelpers: config.maxHelpers || 1
         };
       }
       break;
@@ -115,11 +122,13 @@ module.exports = class LintSimpleUnless extends Rule {
   }
 
   _withHelper(node) {
-    let whitelist = this.config.whitelist;
+    let whitelist = this.config.whitelist; // let { whitelist, maxHelpers } = this.config;
+    let maxHelpers = this.config.maxHelpers;
 
-    if (typeof whitelist !== 'undefined' && whitelist.length > 0) {
+    if (typeof maxHelpers !== 'undefined' || typeof whitelist !== 'undefined') {
       let params;
       let nextParams = node.params;
+      let helperCount = 0;
       let containsSubexpression = false;
 
       do {
@@ -128,18 +137,26 @@ module.exports = class LintSimpleUnless extends Rule {
 
         params.forEach(param => {
           if (param.type === 'SubExpression') {
-            param.params.forEach(param => nextParams.push(param));
-
-            if (!whitelist.includes(param.path.original)) {
+            if (++helperCount > maxHelpers) {
               let loc = param.loc.start;
-              let actual = `{{unless (${param.path.original} ...`;
-              let message = `${messages.withHelper} Allowed helper${whitelist.length > 1 ? 's' : ''}: ${whitelist.toString()}`;
-              //TODO make const
+              let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
+              let message = `${messages.withHelper} MaxHelpers: ${maxHelpers}`;
 
               this._logMessage(message, loc.line, loc.column, actual);
             }
+
+            if (typeof whitelist !== 'undefined' && whitelist.length > 0 && whitelist.indexOf(param.path.original) === -1) { // whitelist.includes(param.path.original)
+              let loc = param.loc.start;
+              let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
+              let message = `${messages.withHelper} Allowed helper${whitelist.length > 1 ? 's' : ''}: ${whitelist.toString()}`;
+
+              this._logMessage(message, loc.line, loc.column, actual);
+            }
+
+            param.params.forEach(param => nextParams.push(param)); // nextParams.push(...params);
           }
         });
+
         containsSubexpression = nextParams.some(param => param.type  === 'SubExpression');
       } while (containsSubexpression);
 

--- a/lib/rules/lint-simple-unless.js
+++ b/lib/rules/lint-simple-unless.js
@@ -15,13 +15,13 @@ const DEFAULT_CONFIG = {
 };
 
 function isValidConfigObjectFormat(config) {
-  for (let key in config) {
+  for (let key in DEFAULT_CONFIG) {
     let value = config[key];
     let valueIsArray = Array.isArray(value);
 
-    if (key === 'whitelist' && !valueIsArray) {
+    if (value === undefined) {
       return false;
-    } else if (DEFAULT_CONFIG[key] === undefined){
+    } else if (key === 'whitelist' && !valueIsArray){
       return false;
     }
   }
@@ -37,24 +37,9 @@ module.exports = class LintSimpleUnless extends Rule {
     case 'boolean':
       // if `true` use `DEFAULT_CONFIG`
       return config ? DEFAULT_CONFIG : false;
-    case 'number':
-      return {
-        whitelist: [],
-        maxHelpers: config
-      };
     case 'object':
-      if (Array.isArray(config)) {
-        return {
-          whitelist: config,
-          maxHelpers: 1
-        };
-      } else if (isValidConfigObjectFormat(config)) {
-        // missing `whitelist` defaults to empty array (wildcard)
-        // missing maxHelpers defaults to 1 when whitelist is given
-        return {
-          whitelist: config.whitelist || [],
-          maxHelpers: config.maxHelpers ? config.maxHelpers : config.whitelist ? 1 : 0
-        };
+      if (isValidConfigObjectFormat(config)) {
+        return config;
       }
       break;
     case 'undefined':
@@ -62,12 +47,10 @@ module.exports = class LintSimpleUnless extends Rule {
     }
 
     let errorMessage = createErrorMessage(this.ruleName, [
-      '  * boolean -- `true` for enabled / `false` for disabled',
-      '  * array -- `whitelist` ```[\'or\']``` for specific helpers / ```[]``` for wildcard, `maxHelpers` defaults to 1',
-      '  * number -- `maxHelpers`, `whitelist` will be wildcard',
-      '  * object --',
-      '    *  `whitelist` -- array',
-      '    * `maxHelpers` -- number'
+      '  * boolean -- `true` for enabled / `false` for disabled\n' +
+      '  * object --\n' +
+      '    *  `whitelist` -- array - `[\'or\']` for specific helpers / `[]` for wildcard\n' +
+      '    *  `maxHelpers` -- number'
     ], config);
 
     throw new Error(errorMessage);

--- a/lib/rules/lint-simple-unless.js
+++ b/lib/rules/lint-simple-unless.js
@@ -39,6 +39,7 @@ module.exports = class LintSimpleUnless extends Rule {
       return config ? DEFAULT_CONFIG : false;
     case 'number':
       return {
+        whitelist: [],
         maxHelpers: config
       };
     case 'object':
@@ -48,10 +49,11 @@ module.exports = class LintSimpleUnless extends Rule {
           maxHelpers: 1
         };
       } else if (isValidConfigObjectFormat(config)) {
-        // default any missing keys to empty values
+        // missing `whitelist` defaults to empty array (wildcard)
+        // missing maxHelpers defaults to 1 when whitelist is given
         return {
           whitelist: config.whitelist || [],
-          maxHelpers: config.maxHelpers || 1
+          maxHelpers: config.maxHelpers ? config.maxHelpers : config.whitelist ? 1 : 0
         };
       }
       break;
@@ -60,7 +62,12 @@ module.exports = class LintSimpleUnless extends Rule {
     }
 
     let errorMessage = createErrorMessage(this.ruleName, [
-      '  * array -- an array of helpers to whitelist'
+      '  * boolean -- `true` for enabled / `false` for disabled',
+      '  * array -- `whitelist` ```[\'or\']``` for specific helpers / ```[]``` for wildcard, `maxHelpers` defaults to 1',
+      '  * number -- `maxHelpers`, `whitelist` will be wildcard',
+      '  * object --',
+      '    *  `whitelist` -- array',
+      '    * `maxHelpers` -- number'
     ], config);
 
     throw new Error(errorMessage);
@@ -122,50 +129,42 @@ module.exports = class LintSimpleUnless extends Rule {
   }
 
   _withHelper(node) {
-    let whitelist = this.config.whitelist; // let { whitelist, maxHelpers } = this.config;
-    let maxHelpers = this.config.maxHelpers;
+    const whitelist = this.config.whitelist; // let { whitelist, maxHelpers } = this.config;
+    const maxHelpers = this.config.maxHelpers;
 
-    if (typeof maxHelpers !== 'undefined' || typeof whitelist !== 'undefined') {
-      let params;
-      let nextParams = node.params;
-      let helperCount = 0;
-      let containsSubexpression = false;
+    let params;
+    let nextParams = node.params;
+    let helperCount = 0;
+    let containsSubexpression = false;
 
-      do {
-        params = nextParams;
-        nextParams = [];
+    do {
+      params = nextParams;
+      nextParams = [];
 
-        params.forEach(param => {
-          if (param.type === 'SubExpression') {
-            if (++helperCount > maxHelpers) {
-              let loc = param.loc.start;
-              let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
-              let message = `${messages.withHelper} MaxHelpers: ${maxHelpers}`;
+      params.forEach(param => {
+        if (param.type === 'SubExpression') {
+          if (++helperCount > maxHelpers) {
+            let loc = param.loc.start;
+            let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
+            let message = `${messages.withHelper} MaxHelpers: ${maxHelpers}`;
 
-              this._logMessage(message, loc.line, loc.column, actual);
-            }
-
-            if (typeof whitelist !== 'undefined' && whitelist.length > 0 && whitelist.indexOf(param.path.original) === -1) { // whitelist.includes(param.path.original)
-              let loc = param.loc.start;
-              let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
-              let message = `${messages.withHelper} Allowed helper${whitelist.length > 1 ? 's' : ''}: ${whitelist.toString()}`;
-
-              this._logMessage(message, loc.line, loc.column, actual);
-            }
-
-            param.params.forEach(param => nextParams.push(param)); // nextParams.push(...params);
+            this._logMessage(message, loc.line, loc.column, actual);
           }
-        });
 
-        containsSubexpression = nextParams.some(param => param.type  === 'SubExpression');
-      } while (containsSubexpression);
+          if (whitelist.length > 0 && whitelist.indexOf(param.path.original) === -1) { // whitelist.includes(param.path.original)
+            let loc = param.loc.start;
+            let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
+            let message = `${messages.withHelper} Allowed helper${whitelist.length > 1 ? 's' : ''}: ${whitelist.toString()}`;
 
-    } else {
-      let loc = node.params[0].loc.start;
-      let actual = `{{unless (${node.params[0].path.original} ...`;
+            this._logMessage(message, loc.line, loc.column, actual);
+          }
 
-      this._logMessage(messages.withHelper, loc.line, loc.column, actual);
-    }
+          param.params.forEach(param => nextParams.push(param)); // nextParams.push(...param.params);
+        }
+      });
+
+      containsSubexpression = nextParams.some(param => param.type  === 'SubExpression');
+    } while (containsSubexpression);
   }
 
   _logMessage(message, line, column, source) {

--- a/test/unit/rules/lint-simple-unless-test.js
+++ b/test/unit/rules/lint-simple-unless-test.js
@@ -6,7 +6,8 @@ const messages = require('../../../lib/rules/lint-simple-unless').messages;
 generateRuleTests({
   name: 'simple-unless',
   config: {
-    whitelist: ['or', 'eq', 'not-eq']
+    whitelist: ['or', 'eq', 'not-eq'],
+    maxHelpers: 2
   },
 
   good: [
@@ -192,6 +193,20 @@ generateRuleTests({
         source: '{{else}}',
         line: 3,
         column: 0
+      }
+    },{
+      template: [
+        '{{#unless (or (eq foo bar) (not-eq baz "beer"))}}',
+        '  MUCH HELPERS, VERY BAD',
+        '{{/unless}}'
+      ].join('\n'),
+
+      result: {
+        message: messages.withHelper + ' MaxHelpers: 2',
+        moduleId: 'layout.hbs',
+        source: '{{unless (... (not-eq ...',
+        line: 1,
+        column: 27
       }
     },{
       config: ['exampleHelper'],

--- a/test/unit/rules/lint-simple-unless-test.js
+++ b/test/unit/rules/lint-simple-unless-test.js
@@ -5,7 +5,9 @@ const messages = require('../../../lib/rules/lint-simple-unless').messages;
 
 generateRuleTests({
   name: 'simple-unless',
-  config: true,
+  config: {
+    whitelist: ['or', 'eq', 'not-eq']
+  },
 
   good: [
     '{{#unless isRed}}I\'m blue, da ba dee da ba daa{{/unless}}',
@@ -13,6 +15,8 @@ generateRuleTests({
     '<div class="{{if foo \'foo\'}}"></div>',
     '{{unrelated-mustache-without-params}}',
     '{{#if foo}}{{else}}{{/if}}',
+    '{{#unless (or foo bar)}}order whiskey{{/unless}}',
+    '{{#unless (eq (or foo bar) baz)}}order whiskey{{/unless}}',
     [
       '{{#unless hamburger}}',
       '  HOT DOG!',
@@ -22,10 +26,21 @@ generateRuleTests({
 
   bad: [
     {
+      template: '{{unless (if (or true))  \'Please no\'}}',
+
+      result: {
+        message: messages.withHelper + ' Allowed helpers: or,eq,not-eq',
+        moduleId: 'layout.hbs',
+        source: '{{unless (if ...',
+        line: 1,
+        column: 9
+      }
+    },
+    {
       template: '{{unless (if true)  \'Please no\'}}',
 
       result: {
-        message: messages.withHelper,
+        message: messages.withHelper + ' Allowed helpers: or,eq,not-eq',
         moduleId: 'layout.hbs',
         source: '{{unless (if ...',
         line: 1,
@@ -36,7 +51,7 @@ generateRuleTests({
       template: '{{unless (and isBad isAwful)  \'notBadAndAwful\'}}',
 
       result: {
-        message: messages.withHelper,
+        message: messages.withHelper + ' Allowed helpers: or,eq,not-eq',
         moduleId: 'layout.hbs',
         source: '{{unless (and ...',
         line: 1,
@@ -140,7 +155,7 @@ generateRuleTests({
       ].join('\n'),
 
       result: {
-        message: messages.withHelper,
+        message: messages.withHelper + ' Allowed helpers: or,eq,not-eq',
         moduleId: 'layout.hbs',
         source: '{{unless (and ...',
         line: 1,
@@ -155,7 +170,7 @@ generateRuleTests({
       ].join('\n'),
 
       result: {
-        message: messages.withHelper,
+        message: messages.withHelper + ' Allowed helpers: or,eq,not-eq',
         moduleId: 'layout.hbs',
         source: '{{unless (not ...',
         line: 1,
@@ -164,7 +179,7 @@ generateRuleTests({
     },
     {
       template: [
-        '{{#unless (not isBrown isSticky)}}',
+        '{{#unless isSticky}}',
         '  I think I am a brown stick',
         '{{else}}',
         '  Not a brown stick',
@@ -177,6 +192,21 @@ generateRuleTests({
         source: '{{else}}',
         line: 3,
         column: 0
+      }
+    },{
+      config: ['exampleHelper'],
+      template: [
+        '{{#unless (concat "blue" "red")}}',
+        '  I think I am a brown stick',
+        '{{/unless}}'
+      ].join('\n'),
+
+      result: {
+        message: messages.withHelper + ' Allowed helper: exampleHelper',
+        moduleId: 'layout.hbs',
+        source: '{{unless (concat ...',
+        line: 1,
+        column: 10
       }
     }
   ]

--- a/test/unit/rules/lint-simple-unless-test.js
+++ b/test/unit/rules/lint-simple-unless-test.js
@@ -22,11 +22,35 @@ generateRuleTests({
       '{{#unless hamburger}}',
       '  HOT DOG!',
       '{{/unless}}'
-    ].join('\n')
+    ].join('\n'),
+    {
+      config: true,
+      template: '{{unless foo bar}}'
+    },
+    {
+      config: { },
+      template: '{{unless foo bar}}'
+    },
+    {
+      config: {
+        whitelist: ['or', 'eq', 'not-eq'],
+      },
+      template: '{{unless (eq foo bar) baz}}'
+    },
+    {
+      config: {
+        maxHelpers: 2,
+      },
+      template: '{{unless (eq (not foo) bar) baz}}'
+    }
   ],
 
   bad: [
     {
+      config: {
+        whitelist: ['or', 'eq', 'not-eq'],
+        maxHelpers: 2
+      },
       template: '{{unless (if (or true))  \'Please no\'}}',
 
       result: {
@@ -222,6 +246,83 @@ generateRuleTests({
         source: '{{unless (concat ...',
         line: 1,
         column: 10
+      }
+    },{
+      config: {},
+      template: [
+        '{{#unless (concat "blue" "red")}}',
+        '  I think I am a brown stick',
+        '{{/unless}}'
+      ].join('\n'),
+
+      result: {
+        message: 'Using {{unless}} in combination with other helpers should be avoided. MaxHelpers: 0',
+        source: '{{unless (concat ...',
+        line: 1,
+        column: 10
+      }
+    },{
+      config: true,
+      template: [
+        '{{#unless (concat "blue" "red")}}',
+        '  I think I am a brown stick',
+        '{{/unless}}'
+      ].join('\n'),
+
+      result: {
+        message: 'Using {{unless}} in combination with other helpers should be avoided. MaxHelpers: 0',
+        source: '{{unless (concat ...',
+        line: 1,
+        column: 10
+      }
+    },{
+      config: 1,
+      template: [
+        '{{#unless (one (max power) two)}}',
+        '  I think I am a brown stick',
+        '{{/unless}}'
+      ].join('\n'),
+
+      result: {
+        message: 'Using {{unless}} in combination with other helpers should be avoided. MaxHelpers: 1',
+        source: '{{unless (... (max ...',
+        line: 1,
+        column: 15
+      }
+    },{
+      config: { whitelist: ['test'] },
+      template: [
+        '{{#unless (one (test power) two)}}',
+        '  I think I am a brown stick',
+        '{{/unless}}'
+      ].join('\n'),
+
+      results: [
+        {
+          message: 'Using {{unless}} in combination with other helpers should be avoided. Allowed helper: test',
+          source: '{{unless (one ...',
+          line: 1,
+          column: 10
+        },{
+          message: 'Using {{unless}} in combination with other helpers should be avoided. MaxHelpers: 1',
+          source: '{{unless (... (test ...',
+          line: 1,
+          column: 15
+        }
+      ]
+    },{
+      config: { maxHelpers: 2 },
+      template: [
+        '{{#unless (one (two three) (four five))}}',
+        '  I think I am a brown stick',
+        '{{/unless}}'
+      ].join('\n'),
+
+      result: {
+        message: 'Using {{unless}} in combination with other helpers should be avoided. MaxHelpers: 2',
+        source: '{{unless (... (four ...',
+        line: 1,
+        column: 27
       }
     }
   ]

--- a/test/unit/rules/lint-simple-unless-test.js
+++ b/test/unit/rules/lint-simple-unless-test.js
@@ -28,18 +28,16 @@ generateRuleTests({
       template: '{{unless foo bar}}'
     },
     {
-      config: { },
-      template: '{{unless foo bar}}'
-    },
-    {
       config: {
         whitelist: ['or', 'eq', 'not-eq'],
+        maxHelpers: 2
       },
       template: '{{unless (eq foo bar) baz}}'
     },
     {
       config: {
-        maxHelpers: 2,
+        whitelist: [],
+        maxHelpers: 2
       },
       template: '{{unless (eq (not foo) bar) baz}}'
     }
@@ -233,35 +231,6 @@ generateRuleTests({
         column: 27
       }
     },{
-      config: ['exampleHelper'],
-      template: [
-        '{{#unless (concat "blue" "red")}}',
-        '  I think I am a brown stick',
-        '{{/unless}}'
-      ].join('\n'),
-
-      result: {
-        message: messages.withHelper + ' Allowed helper: exampleHelper',
-        moduleId: 'layout.hbs',
-        source: '{{unless (concat ...',
-        line: 1,
-        column: 10
-      }
-    },{
-      config: {},
-      template: [
-        '{{#unless (concat "blue" "red")}}',
-        '  I think I am a brown stick',
-        '{{/unless}}'
-      ].join('\n'),
-
-      result: {
-        message: 'Using {{unless}} in combination with other helpers should be avoided. MaxHelpers: 0',
-        source: '{{unless (concat ...',
-        line: 1,
-        column: 10
-      }
-    },{
       config: true,
       template: [
         '{{#unless (concat "blue" "red")}}',
@@ -276,21 +245,10 @@ generateRuleTests({
         column: 10
       }
     },{
-      config: 1,
-      template: [
-        '{{#unless (one (max power) two)}}',
-        '  I think I am a brown stick',
-        '{{/unless}}'
-      ].join('\n'),
-
-      result: {
-        message: 'Using {{unless}} in combination with other helpers should be avoided. MaxHelpers: 1',
-        source: '{{unless (... (max ...',
-        line: 1,
-        column: 15
-      }
-    },{
-      config: { whitelist: ['test'] },
+      config: {
+        whitelist: ['test'],
+        maxHelpers: 1
+      },
       template: [
         '{{#unless (one (test power) two)}}',
         '  I think I am a brown stick',
@@ -311,7 +269,10 @@ generateRuleTests({
         }
       ]
     },{
-      config: { maxHelpers: 2 },
+      config: {
+        whitelist: [],
+        maxHelpers: 2
+      },
       template: [
         '{{#unless (one (two three) (four five))}}',
         '  I think I am a brown stick',


### PR DESCRIPTION
This PR adds two configuration options to the ```simple-unless``` rule:
- ```whitelist``` - an array of helpers to whitelist, e.g. ```'simple-unless': ['not', 'or']```.
- ```maxHelpers``` - number of maximum nested Helpers, defaults to 1 when at least one Helper is whitelisted. Setting maxHelpers without whitelisting at least one Helper will allow all Helpers and only apply the limit.
 
closes #353 
