### PR TITLE
Remove explicit `@glimmer/syntax` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@glimmer/compiler": "^0.30.1",
-    "@glimmer/syntax": "^0.31.0",
     "chalk": "^2.0.0",
     "glob": "^7.0.0",
     "lodash": "^4.11.1",

--- a/test/unit/helpers/ast-node-info-test.js
+++ b/test/unit/helpers/ast-node-info-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const preprocess = require('@glimmer/syntax').preprocess;
+const preprocess = require('./parse');
 const AstNodeInfo = require('../../../lib/helpers/ast-node-info');
 
 describe('isImgElement', function() {

--- a/test/unit/helpers/is-interactive-element-test.js
+++ b/test/unit/helpers/is-interactive-element-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const preprocess = require('@glimmer/syntax').preprocess;
+const preprocess = require('./parse');
 const isInteractiveElement = require('../../../lib/helpers/is-interactive-element');
 
 describe('isInteractiveElement', function() {

--- a/test/unit/helpers/parse.js
+++ b/test/unit/helpers/parse.js
@@ -1,0 +1,5 @@
+'use strict';
+
+let compilerPath = require.resolve('@glimmer/compiler');
+let syntaxPath = require.resolve('@glimmer/syntax', { paths: [compilerPath] });
+module.exports = require(syntaxPath).preprocess;

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,12 +18,6 @@
   dependencies:
     "@glimmer/wire-format" "^0.30.2"
 
-"@glimmer/interfaces@^0.31.0":
-  version "0.31.0"
-  resolved "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.31.0.tgz#642764765b266d5cf921f64354e06a3112551081"
-  dependencies:
-    "@glimmer/wire-format" "^0.31.0"
-
 "@glimmer/syntax@^0.30.2":
   version "0.30.2"
   resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.30.2.tgz#c1acbf44d4c73e7b112192c398e71476cd24e825"
@@ -33,34 +27,15 @@
     handlebars "^4.0.6"
     simple-html-tokenizer "^0.4.1"
 
-"@glimmer/syntax@^0.31.0":
-  version "0.31.0"
-  resolved "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.31.0.tgz#5e4f2732c39b07060a716a95e55e7a67c7d1a213"
-  dependencies:
-    "@glimmer/interfaces" "^0.31.0"
-    "@glimmer/util" "^0.31.0"
-    handlebars "^4.0.6"
-    simple-html-tokenizer "^0.4.1"
-
 "@glimmer/util@^0.30.2":
   version "0.30.2"
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.30.2.tgz#dd3ed4293b97ce7d89f3b8682381e666c43ba6d7"
-
-"@glimmer/util@^0.31.0":
-  version "0.31.0"
-  resolved "https://registry.npmjs.org/@glimmer/util/-/util-0.31.0.tgz#45e353a7dcaffe6df00cc3d729153ae6121cf0e4"
 
 "@glimmer/wire-format@^0.30.2":
   version "0.30.2"
   resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.30.2.tgz#ce4a4c903ada28ee2c62b857b69dfdc06512f53a"
   dependencies:
     "@glimmer/util" "^0.30.2"
-
-"@glimmer/wire-format@^0.31.0":
-  version "0.31.0"
-  resolved "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.31.0.tgz#5a12e7a770a981ce9ea3a7daf737433bd6cd03d9"
-  dependencies:
-    "@glimmer/util" "^0.31.0"
 
 accepts@1.3.3, accepts@~1.3.3:
   version "1.3.3"


### PR DESCRIPTION
... and replace it with the `@glimmer/syntax` dependency from `@glimmer/compiler`.

This will make sure that we are not relying on different versions like it is currently the case.

Closes #349

/cc @rwjblue 